### PR TITLE
chore: Update Metadata from Snapshot 2025-08-23T01:53:52+00:00

### DIFF
--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "e57a1aab5a0c83e33346d37fc2fbe80b379350e90ab502400ce2bded34976722",
 	"sha512": "b4533d3880b02b909c68dafd85d85fce15f6320a0c4d9636856e99fe71b49bcdb5bf63aa43364873eb97bd8df1d75aa98ba9e8f624ef5d28f62abdc1ec769678",
 	"descriptionMd5": "1a966ebfced18bd20e35a5e3801b8580"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6192,
+	"md5": "583dda7a1e511fb34f3c27fd58321bb7",
+	"sha1": "3da410ee3bc2d2f2fd5cac9de8da8d52d45e8c67",
+	"sha256": "e2ecc39d6c6f7faf099b3802b16d5ece12644b4e74e58a169bfcdee9862a9248",
+	"sha512": "60afbc772e2b891569f59538eb349f729b87506e88d394fe6e1ff72e01990679937038ba447236a4536a60161847b285c80b6dd1ff0ca81b3c096f3e401a44a5",
+	"descriptionMd5": "1a966ebfced18bd20e35a5e3801b8580"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-azure.json
@@ -30,6 +30,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-525-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6188,
+	"md5": "9ac5f1f48088c2615cdad51317704e3c",
+	"sha1": "9c0a0e11709d4b3b24ee3624660e4c8d671c5135",
+	"sha256": "1dec634f7bd0380609ca2feaffa00d9803add2f7af6b2fc0c0e2ae1c9fcbd289",
+	"sha512": "48e56cbe44b76af93cd39e22ed8023421999fe7f9d0602e1273538ac56cd18ae2a79cfbc46ba47f7c13c2eb90cfd394cd3c3d3ec7e55ec43b3d66c854a60624f",
+	"descriptionMd5": "1a966ebfced18bd20e35a5e3801b8580"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-open-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "a0fe5f2bdf59e8beec0112c100942c283f37c0cf564cc06a61e8dba26f8625fe",
 	"sha512": "7a94aed8d6554810fcf02528e30a91f9db897b48ce0aee3740bb343e65e2f9aea260a10d6eb06ccddb7a846c626f6c9aa657c2843c7dcd50b0311ca6088e1d40",
 	"descriptionMd5": "83e74e97cbe820ad1c52335751c73e4c"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6212,
+	"md5": "edb5c7894e4d8da6bcb9b2a138883c27",
+	"sha1": "1dd4454627fc9738dbd0673e5876c10f1ee32a7f",
+	"sha256": "4bd23d9819c6a78f07f9cf6f7667e30a95197959843a2cedd1eed1b9a18a1c3f",
+	"sha512": "bbd55c12d6ee3932b4fe44310f1a8a54bb64d5c5a80dfec0d978be52b32e71a74b4cfc6b3dd7edbf38ee09d94cbd44689aa5ed5f2c778839edaa772c399896b3",
+	"descriptionMd5": "83e74e97cbe820ad1c52335751c73e4c"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-open-azure.json
@@ -30,6 +30,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-525-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6196,
+	"md5": "65576ecd5eb1ffd5286b7e18fa8a85d7",
+	"sha1": "f0c0e717c5cdcc519aedff229b8d02a0eebf92a1",
+	"sha256": "be996852ba8a94eb9099564db61ca29111539d6b4fefaa87da4b0f794cbfd7d0",
+	"sha512": "0bf8ec5d7ba32eccb8618b35a31965ce4ba5a97895589c1738319656975576a8cf9add0fc8f2f2ce94ca87ffdd6fb8df8a26c66935f1778a486934fb987bfb5a",
+	"descriptionMd5": "83e74e97cbe820ad1c52335751c73e4c"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "e92a1aa3be47d99faedcb373d9d14f067645f505caf5595113bef5f16760e8d9",
 	"sha512": "16cda1d033a18f92380cb62e0b1ff88f26e98c8c8490e77b8628cd4a2388c7f682c2bacc7e67628b6dd6b614bfe262702101dc6986234acb9e24ddca2797b723",
 	"descriptionMd5": "11968f0fa2fbcbc57df2f70779a446f9"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6210,
+	"md5": "b94c683b6e36dd8eda89ace7c8ed95f0",
+	"sha1": "fd0e37ed983f16e3c6ed915769793325f1f75c19",
+	"sha256": "98bc350ae5de673938b61d5916d7cb1bf4ddebd630f496c7a79619651290dbd4",
+	"sha512": "6ae2f2ad3fafdad6b9dc4ef0c1a8f95e7ad1e5cd12878d82944466fe5af41ba203c2432a320ffaab5add1b891851c8fb8948846dac7995178ce5efacd560131a",
+	"descriptionMd5": "11968f0fa2fbcbc57df2f70779a446f9"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-azure.json
@@ -30,6 +30,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-525-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6198,
+	"md5": "5c1877ad165d583bfc2c71bf13ef48ff",
+	"sha1": "41b693d05a3552fb9f44ed2ff9da969503f80cfe",
+	"sha256": "ac0abd8c4308cff18a6336dc2a4c56ae92451ef561b0fbff4b5d320f2633039b",
+	"sha512": "107fd343ccfa483af641649d3c3f74acab901b3b41badf51b39ba8be6d5a2c2701702106a8de24c1244f6abee4d405fe05ea3a922c1e73360e3906adb70fd79a",
+	"descriptionMd5": "11968f0fa2fbcbc57df2f70779a446f9"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-open-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "247f7e7fb778d380c9eed3014e1b6a87768b11c765004082c8b329fd0e28ce5a",
 	"sha512": "9a6144c24a7a0997f81bc23657dda0414a4f9d5b97bd38eddbee7e731c0c23ab9fa305c44500a1bafa5d901eee71f0a398bc5ded9cbcafe5f9d0c8a50b34b10f",
 	"descriptionMd5": "77b5b4c25bf800e4ceb145692e9a171f"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6222,
+	"md5": "bb50153e2ef80d92862e3a26eefbcfd0",
+	"sha1": "6ba4bddfeefdb2c03a5a677fc5833aa0af61c377",
+	"sha256": "53a4c46964ed23c1fe117ec52e5bb651343c3b19397e7874177ebd4f0018158a",
+	"sha512": "f7f9a221329de0c5fa87a0b23cab0b7834ef2d0a13498aab6403e21c6475eb0ffabcbc0d26b22a43410c1f43f23423ac44165dfb94e1c9c11fbf3f8be78dd8cf",
+	"descriptionMd5": "77b5b4c25bf800e4ceb145692e9a171f"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-525-server-open-azure.json
@@ -30,6 +30,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-525-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6206,
+	"md5": "45537fd0be4a8f7804b6b1411045f859",
+	"sha1": "72cfea99b651b2b3e0ffb4279ee49fec3011178b",
+	"sha256": "216706dcaf11193c70f989915df91aa7bedf3e45d22ec4dad78523899d4f799e",
+	"sha512": "1c1552cda2c3898f9a7a721ec27cc10f6d85eabc1c62cf6017d163d344357f776e9f9d5a9702b724f2fd55d3bb6c4aa4909ba8b2f6aeb76c5840a4119f064486",
+	"descriptionMd5": "77b5b4c25bf800e4ceb145692e9a171f"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/oldlibs",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "8894651ba0cf9dbab89c44e857671a2599a3bd5cec05ff67cd1829adffc55650",
 	"sha512": "947fea9c241013e9b4bdecfa0ea42b8ff4bd7cbe34e9f94da5b0eaa18a9a0b034b574c5786a81ac730802aa1f6aba3d753dfa5cb611d64d2af87535bdba0ff47",
 	"descriptionMd5": "ba17f60692683b47bba97ee6af14fa93"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6258,
+	"md5": "7ef2e9ae890eac6b14944a854744bc87",
+	"sha1": "e55c5545e7f89423ae6a300f73bd9fdac0d900d3",
+	"sha256": "fb8f275d3fdb3fdbe61ac315175d770f5ec049d330385a79473fbd812ee1282c",
+	"sha512": "730ce388e7dcf5751ce13b7cb426ec06608e8f162ff5b048786d23d0cd5159655e316c13422e135ee394b696321f365350d56ef6414272cd2fad7625ca37f635",
+	"descriptionMd5": "ba17f60692683b47bba97ee6af14fa93"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-azure.json
@@ -31,6 +31,32 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-535-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6252,
+	"md5": "f3caad04ec7ced8d583211cd6600a12a",
+	"sha1": "54e39a572c88e79fae3ccda72a805dd96ab13c3c",
+	"sha256": "01adabf5544df48665536fb5edbe5774cf0a9220de2b3050fd71a75da8a49e7f",
+	"sha512": "b52b3690d92d9bf03fb74f4ba81f49e2a088039feac29946e29549acf97febd9384f988fa99df575bf2e4789841103f76463a626cd0175ff819c8e5001234de1",
+	"descriptionMd5": "e7b1741d46142078245c051e85ad0e17"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-open-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "97348c3b49316e764eadc8407d1bc45eb91dc8e26ef43647e040a74413bb21c1",
 	"sha512": "993691b27614685cd403d56292b306a0db89fbd7b03ee141cf9a0609d004fef22a837fe67c033005493f1d08cf6d43a1192476bcdfce12f9f4527c42d60f5efd",
 	"descriptionMd5": "5ba566bace29db7ae101d1da543908d7"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "f12d60de93819dfac038525db75195f1",
+	"sha1": "011af4b159bdf65bb3fa50a212113a5df78e3e92",
+	"sha256": "903664dde167912d2a67b7ff9a80d1ba8d16fd3450238728834ff33daca3e051",
+	"sha512": "e6bba551f085b9656beb032b3a50d3492ad67552c28c5f12a4cd283d89085a6b7be9e17b69c60242d1ffc67c4306b854b20afeab25782a953af129ed1d1ac4f7",
+	"descriptionMd5": "5ba566bace29db7ae101d1da543908d7"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-open-azure.json
@@ -31,6 +31,32 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-535-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6252,
+	"md5": "ce1cb21964836b5a9b5312fbd9c10a21",
+	"sha1": "64f2342abf0c51261471789a09605492042ec046",
+	"sha256": "5c5ecf532dc9ef4c3e80197660eb4d9edaec6560b8bc5ca9e1dcd93c5d59e206",
+	"sha512": "d1ed789e508ff9bca8e255553e38f5af70af5c40f612f5cdad197a7ca035e1e95500054f541872fdab89a99016512591edfeddc6bac8af34aec42565f307770a",
+	"descriptionMd5": "badb506668ccd67f84e168b091aa78af"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "1d48242f2650a310651eeed1f97f5441db3353ddb68b0f7ab8a5580f4caf8386",
 	"sha512": "a9ef3d49753e6a625c791e3d16c497c79aca7439e3a4d627f4d720cdac95cc548a4eb2f7b55ea8f1e3dd554aceed1f89879af973dafd77da679edabfd4f38c9b",
 	"descriptionMd5": "235738b2df75562def82c33a0b77bd55"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6272,
+	"md5": "c85a6b324f5ed53f806ff1023f95d6b4",
+	"sha1": "b39698132e4afc96915a76e046d5ae6e352e8e6c",
+	"sha256": "5f63c9d09f5090bf654f718a65aa1568acf187f5312c39c2f8be8ee2e787ae55",
+	"sha512": "e9bb8eb511b56ab61fdc3786bf68e0245d6e07610c563032a4192dd0ced7291c0b37de638591958b9dd1f5512e1bd61b4ed7552c8d9f4d2314ccdba5c4685eaa",
+	"descriptionMd5": "235738b2df75562def82c33a0b77bd55"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-azure.json
@@ -31,6 +31,32 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-535-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6256,
+	"md5": "ef41109d6e056709a8c79fd240d3c95d",
+	"sha1": "23dd0a57d15cdad44030367ea33f11d1e4f95ca1",
+	"sha256": "6b7f8aed106e481dbb6b87b9510dd4ea4b615ea0b2c77ecc4c0a01b1bab9789b",
+	"sha512": "9d0a2f0459bdcab02d4bea46142202896a3a6f3295e44faa0c89db32a9953783f0968bda290d8ce1d3180e486653035b588de6acfad0f390bded39a1b03e87fa",
+	"descriptionMd5": "b471568297983138cd4343bf82f58281"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-open-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "387fc64bcb1fa8e30ac193ecf99cbec5c028153af116843fe499895d20813ff4",
 	"sha512": "4ada9c084630c4d808ceae6c2f765eedc9f5c895ec84a26d867c87e372ac637f5588853521e7c74257aaea6a40c88d467ca19823500a882979713f9c3e9318f5",
 	"descriptionMd5": "c30b13c5e23086ea4243ac1ea46deee4"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6282,
+	"md5": "6a90ef165206412b7625c6672ae8bc01",
+	"sha1": "646a5dd046b69c36bafc887c3a3963fe87339f5c",
+	"sha256": "5b8fa2f1c3af19a5a037dbb35f3fd28ea7ed2b430a04481b1cd197bbdf037f94",
+	"sha512": "551a2814488f9ae5a22908d64fd273a5b0ed2ba882daf53cc301c6982826992bcc72ec70232b61f7f90ca989d1f1a62183572beca34b2c465244fa1f5e929e5d",
+	"descriptionMd5": "c30b13c5e23086ea4243ac1ea46deee4"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-535-server-open-azure.json
@@ -31,6 +31,32 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-535-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "d2d9baf736da7a62ee6f22fb9c7f4eac",
+	"sha1": "a1c946eb5bd006775e33609e90ff5d0643c3bc81",
+	"sha256": "8abbedb402a5125d5f8ff7ca227f497394db5eb7194cae86336fc8b89cc2e44c",
+	"sha512": "8efc646add4302b6c9006bb29fe429f35659d68ce87a63bae9fb5c7f3f3eae57e80f54e10e2a0e898e7e8fffaf1deb2d3a6f65d81435e87039429d7801f457c9",
+	"descriptionMd5": "ac9f68bfe3ce8d821cec0a5cbce25afa"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "b66b6a90a866b3712f35e95b5e778b8e12df7bd30a89c2c470f295417b5fb6d8",
 	"sha512": "46a30bd042586b556fa3d5bc2b0ead495960f5ff535528ef21da6a9b55271054885faa167ef0edde0cb45a92bd15f72e52d768ef086e201c6926d422a6fe4de3",
 	"descriptionMd5": "4a16566af1e380d4e9aa573e84c9d827"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6192,
+	"md5": "85e820bbe71971a42654374fcdf9b839",
+	"sha1": "f3b4307a3a6787fc0020c6043d861159da2126cc",
+	"sha256": "15f5aacf30c3ee90bc446ba1b89016c79b79d575aee460c76c3bf40df4f39bcb",
+	"sha512": "211dd7ea01f233efef7e323f799b8cf0f7851e4317bf23957554029402b4f3d2117b9519d1bb0e4627cea5eb5a112d6d1f687e2bb10d65a9c54b9f5b9789be2e",
+	"descriptionMd5": "4a16566af1e380d4e9aa573e84c9d827"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-azure.json
@@ -30,6 +30,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-545-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6186,
+	"md5": "77436c04861d85846e330e2305dfa151",
+	"sha1": "f3306577a0f0a7f228cae30a36b0f2ece71f3b07",
+	"sha256": "ee4065180f0b3821d2f23efbd85b8132454e0f23f2ae7030d11f248311f2ecc9",
+	"sha512": "a91853d5423a87c80fa20da240151093089d07a5abd9a2d31d8d09f67e57643f852c6614b909101ab0caccae32cc7446b57d6f37bd869ba06e22c284da0dc500",
+	"descriptionMd5": "4a16566af1e380d4e9aa573e84c9d827"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-open-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "981136d02b58e7a1c8fbe90bb8944ab7f419ff4f241b4a95af0cc5f54a270f87",
 	"sha512": "ffc5a23027cb20c3e5f323f6692da082cb82d5b1e122dcb0f0bb30b2bf599508465c63bb9e64b509fd079ffd868ac2adef1a68be6a9497082459b4ac864949cf",
 	"descriptionMd5": "25897d1311a34315523732010ffb4936"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6210,
+	"md5": "5af948558d1a1be1dcf9a32c2d02abb2",
+	"sha1": "818d2f3adf5d9244a6d7ab92aeec1acd2a85228e",
+	"sha256": "7695b81b5f02efd5cccc9d52234d156f7ce0a6c100e229a192f9679ed1edef9c",
+	"sha512": "dc480ca3a197fe37433bca2f586ac969035e07ff54287ed7663517295e765edf9b387d8a3c4e51385c2d8ce6fd233862edcac3b0f4daa6c414d6a87576fa2099",
+	"descriptionMd5": "25897d1311a34315523732010ffb4936"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-545-open-azure.json
@@ -30,6 +30,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-545-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6198,
+	"md5": "72339e4f28267e004cbd4d981069fa93",
+	"sha1": "1c5b62c8958409e1a9f0740c796377760856ba3a",
+	"sha256": "83b74c8eb0b9ba46a58cbef03130bbbb2a9a449829280db8156e5f2d764268a3",
+	"sha512": "7fc0c96ebeeb21a5c8090085464cf124e18ce767e8e16d9af66e3142a476c8b75333fe1720b9cf49b0bf5523f49cab60051b13606b5da66cdd7c8f477fe6cd62",
+	"descriptionMd5": "25897d1311a34315523732010ffb4936"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "5198d50f70c328ce6237548b1963283af39c59c0c5ac2c4f163f1e5d676f8d09",
 	"sha512": "827c74d9b1d180f2ff6c13303df0cff5a7a920de69706e71f86453e2831ff13ae8b435bab633f77561c1dae8de6c03178e83985618a3e5867653db2d9045abcc",
 	"descriptionMd5": "07790e32d063c4c88a17f5393725225e"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6258,
+	"md5": "518115966b152295bf524447f36661cb",
+	"sha1": "aac4bed74906f890e0898078173c42b8d1b3e952",
+	"sha256": "3843a08b826a41d190fa6cae329f7a12bda866bc36d2078a1dacfb06f82e0f77",
+	"sha512": "203696f4533ffcb8e7c4850e109abdc46d1bac52c85831d52e0498ebcb911ac265a141e3b38cf0a9a60fa8f4bab615f458f295175667ed0621b0df46d400bd78",
+	"descriptionMd5": "07790e32d063c4c88a17f5393725225e"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-azure.json
@@ -31,6 +31,32 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-550-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6250,
+	"md5": "393b34692d346b1b4c7450d6d39d6551",
+	"sha1": "753215e69e71fdc645f7d43e37dfc14181ce2006",
+	"sha256": "3646e9f69d5d4affe7bd54c441e1f9231d0a4955a474e385eba721e6160478a2",
+	"sha512": "75b65dc491e4ff2c253537a66ea555d96574f963e430fd3f97f1ca26d6a21609b75c674442e39e9c60d72a4b051cbf23c6822eebd6073eb76aad1dc0114c6513",
+	"descriptionMd5": "88662ddf4d9b38672437027f5d9c3ca2"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-open-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "83cf9064e8b8d5cb68784f1aa3643011136c3f93624e3a973a65e72569482075",
 	"sha512": "86867b391ae737e94f8bc2a1551ed71bcfd924d438946f8e299f0dea7109b366d807aa56fea14c81e9d39b9027cc767b2d7aebba5417bf129b6356e5d9d87c8f",
 	"descriptionMd5": "6f9cd416f4f44c6d0074a665224d8abc"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "24bad75960c2b973e4409d8882514faf",
+	"sha1": "e9a94315ef854d7f7229e10f93581d05a97ce11c",
+	"sha256": "bb82964f493700ae9d36243c3237cce90b17304614c9616d6384aa56ef598d07",
+	"sha512": "45978ea3eb618c21df0159b64a72ebef7bb9a04d0a204c567d62ee19d8602c7c67cd41baf2a142ae3aa8c6c30b0870caed9f203b1999436cdad48fc2ee676d5b",
+	"descriptionMd5": "6f9cd416f4f44c6d0074a665224d8abc"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-open-azure.json
@@ -31,6 +31,32 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-550-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "e445c9747f6925ab26043b20084caf8c",
+	"sha1": "44ffc38f240534e671838ae446ca9e261a1b1524",
+	"sha256": "8f14a27d57279b240445617422b20e7c10d658c4a315ccbc64912df742a53398",
+	"sha512": "2efff4bb2c4fa7d6dab61be1d3add11772940188f36965258ae0a63ae99d8960be1c5e9c34b92970b15a3fb96f559823c06706bf20baa55274ab47ba51ecad69",
+	"descriptionMd5": "5b71184ce4017a233c641fa6143f0ab7"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-azure-edge.json
@@ -24,4 +24,29 @@
 	"sha256": "fd02acdb8511bb5f014d811bb5d4307ff96e298dff2af0fd3e80ebba53411870",
 	"sha512": "97319243e8b80312216cd3670a1de7211acd9b0d01eb993f724543f21fdcf588ca382aca3e22c8c1b641fff86edf66c3f40d2e768c428a63302c6d2a9276c563",
 	"descriptionMd5": "70d9f3bbf0b069c23f76ea95f119b8f4"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6212,
+	"md5": "85cbeec700940b45d874c493beaa7c13",
+	"sha1": "91b5c538add3bc68470d0d59b0f30d24392ba332",
+	"sha256": "ff9add551de28ed09020568a390fd5cd0fbe4678a10eb78ed95d71d65af9eafe",
+	"sha512": "fca41fd19f2355c8bd4a96a7bdeb7bf45af31d26f79b5b74e7ba5e8428201196b8a5ae6ce56bbefcc223e4d5a1a6cff9694fc20c629c9e5569cca736105b19f7",
+	"descriptionMd5": "8f5e9e4b3ff3bbc23f536186b3008a1c"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-azure.json
@@ -31,6 +31,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-550-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6196,
+	"md5": "6995dd4a0d00dfdeba0a3a5d786114dd",
+	"sha1": "cf333ed808d680af56fdda007cc4091eec377906",
+	"sha256": "01e83fd40b5e38d981f1311a5812934a9f7052caa67f064223c85975254f134e",
+	"sha512": "08c9d454e3a3489ceda3f633622bdbf96867176de9aa166f524307dcb1c8ad4d1c1fd0fec80d1f2eec019383177720450945df8a8ba80b12cfa9daffd2ac7966",
+	"descriptionMd5": "8f5e9e4b3ff3bbc23f536186b3008a1c"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-open-azure-edge.json
@@ -24,4 +24,29 @@
 	"sha256": "d15dd1db86d36a5ade988d3be3efdea99c7ce3822020ec0898564f0669264409",
 	"sha512": "7d789e9c6d3ac78214ccdd490d05bd5a7f3eed4bd0ca6c65c37c3f12d29ac5895bde9805dbbe1b0de30319756ef9f84f3676e900fef1b44c4d64685f05a9bd31",
 	"descriptionMd5": "e53a8741ef90744556cdd3ab7075782e"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6224,
+	"md5": "492ba20ada71160a26dbabbcc9137008",
+	"sha1": "1f1b18d96cdeda11fa989e9fcf2be28f459446e7",
+	"sha256": "2e60fbb8f7edc9c18d625434d1bef3b86673611c8befbaf6b524b0bb0c175333",
+	"sha512": "de10fce3567f0ebc2f2bf0141b42950b4d3ca3691431606711e2f2526af00ff06283cd752e37358016940178c9ae94c242544bbf19a1501beed56bc7cfc5c973",
+	"descriptionMd5": "8f1837212f159be2ae3215f13992aeac"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-550-server-open-azure.json
@@ -31,6 +31,31 @@
 		"Size"
 	],
 	"package": "linux-modules-nvidia-550-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6206,
+	"md5": "ef95f6f06f7f9a25c51eeff388a2dafc",
+	"sha1": "f3bf4cb202d89ed822c02b31d737ed57b62ed49c",
+	"sha256": "35e8acb34fff046a021dcfcb65b073d28f8fad13660cb16b5506add78ecae95e",
+	"sha512": "2267abab7ce78c08bbeb5af52f43413658db4e8acc11438814a0e040a3e66491d8cdd3f65509992c8107d88b602932ed05ce372f147e7372a4fe5b4b93df71c9",
+	"descriptionMd5": "8f1837212f159be2ae3215f13992aeac"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-open-azure",
 	"source": "linux-restricted-modules-azure",
 	"version": "6.8.0-1007.7",
 	"section": "restricted/kernel",

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "5ec0bd1e5ef503c6c646e3d4aa2baee202438dce9b55d7192cfbad69bfa7e8e2",
 	"sha512": "d69b8cba897fa27952ddc0f2f6ea778e1af81aca7d67393718be54fb5b006c2390ec37f6a829aa9e89cf7f2f6b138d07340fa47d211395af962ccf3b9bf76264",
 	"descriptionMd5": "ec35a657849543adb1634fa05315385a"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6212,
+	"md5": "6d5f3655973de12ff6edca07e00b46de",
+	"sha1": "6a683c34be6e9a77b2960e4411960c23d87fc792",
+	"sha256": "5ed21b550cf134fe2fa525c2c626dd9a2d833332049f685ac3c74fb54e4dfda7",
+	"sha512": "d7f7cfc5f98c5d8348e27952f2460795eeacf5062e873ca0d7da2fdd6d5dda2c461eea68fb75e4152cd07393144f9dbb7b64953254ae277919c5ea1bef911bd1",
+	"descriptionMd5": "ec35a657849543adb1634fa05315385a"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-azure.json
@@ -23,4 +23,29 @@
 	"sha256": "2fab28e7fdc375086e91d0e04554dc3882d6e194c2bfa3cdd6f67b27cb021e01",
 	"sha512": "a7a28d1f4c816f076a679814317c20f792900d2cb323d47794dab7c4284daa4086850b67a26e242a91a42209f98d84b2dd597932e50332c64502c8eb5d3259c7",
 	"descriptionMd5": "ec35a657849543adb1634fa05315385a"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6198,
+	"md5": "0089e68e61f83d2106bb7b540ef08707",
+	"sha1": "c3af89a04487be616d5e3f0f02fc75a337f20787",
+	"sha256": "04ed6b31c5b8750e2a672066c4681d96ae9db0024acb83e5c7e68ff005546c3e",
+	"sha512": "25c3701dff9bcf7be418ed197256596461f00c2c823e2f505eab64c2624e4b2778462c511ced399e70edbf6584a272312d9b44a59560d36d6d44253e6f175672",
+	"descriptionMd5": "ec35a657849543adb1634fa05315385a"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-open-azure-edge.json
@@ -23,4 +23,29 @@
 	"sha256": "7eb5c6b9f355c8f9ff32e0fbc1f5b19ed193e35c2cfd283c539c9217f89e4b4e",
 	"sha512": "5e44b2593539942047ed11c843115a3bc8b8d3ae9ea20dfde38b4872276f14d80987ccdcc352f7b2adc3be5c4be5f23e22b3777dc6a001e550ba649003ffa0b9",
 	"descriptionMd5": "ea3a481c0c39cd40fdcc64046808c6c8"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6228,
+	"md5": "e26f70922e12293fa17bff7cc886457c",
+	"sha1": "f95914f4881d57f9866b9d3fa038cf7bbbc58e9a",
+	"sha256": "0587dea3e1d41ba6f875d8542fcfea6e8d2bd4e2eb5d5b84345aa35b50930520",
+	"sha512": "4cf046ce638be033eb34a98323c7d44b3f15c5776b95e0a99964087bbc35628ea328ed55008c38b6fdd6a1ef75c678252d245d763299ae4186dbc4cdc82e404c",
+	"descriptionMd5": "ea3a481c0c39cd40fdcc64046808c6c8"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-565-server-open-azure.json
@@ -23,4 +23,29 @@
 	"sha256": "cb8353567aa4da29f1ddccc1ba5ad03eb052756829655cb663a9395def86c578",
 	"sha512": "7ccae3cdf98e2c11bec085fe49fdff0e2aabd36c2bf81502dded17a26daffce581556dfd2e575bba6bf341771d8119de98e1c1ad8c051cd18fab6853ad7bed1d",
 	"descriptionMd5": "ea3a481c0c39cd40fdcc64046808c6c8"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6208,
+	"md5": "08f7daff274595bdc1497ee3abfa274c",
+	"sha1": "da8c4b828efbd9e38fcc400e1f894059bf2ec2b3",
+	"sha256": "ef52216bb5ebbaeefde94fb08b736fb0f27ababf826c75a665a35e05fc768e18",
+	"sha512": "1ceb177f8f4bcf6c330b0795d3dbe2c4aed0381a87b5f687e0d7426f868b9b0d2b42228a04a40e3de924e1736083374401e2d4535027dbdf889d45f2c967d9de",
+	"descriptionMd5": "ea3a481c0c39cd40fdcc64046808c6c8"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "80fd18ebdae706c5f37fd9b1ace91e8ffe451e4cb5e47d74daa0f89a5a3e7c0f",
 	"sha512": "223a97c71ffdd9edf70c39b682893d6d810071728c387c284836bed94951fc603606ea79c466251019e6ee52d984491d3bda0e3987fb885a2c65adc987dd9047",
 	"descriptionMd5": "5ef022f18c9b59ae406a9e2938c1dae6"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6254,
+	"md5": "c8e4a726837068b339363fe63b370f05",
+	"sha1": "dc2d7686f62c42b254a0aae79a48244860ce240f",
+	"sha256": "5961569c73e55f53f71ae188446942e036f00ec81823c7dfe73d249220c37b29",
+	"sha512": "72c0cc5c773f6d440c747c3648c5136ffb02649221d00e93df3a03c2193991c6ef2a645620e59122d07a787668d1a35ab0138af9339f3165d9676e67cf27b57b",
+	"descriptionMd5": "5ef022f18c9b59ae406a9e2938c1dae6"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-azure.json
@@ -24,4 +24,30 @@
 	"sha256": "17beaa81635317836de8c7e5dabc14003050adf7418330c133a89a53c35eae59",
 	"sha512": "ed30fbc941af3d75a76f512a07572ec3cd9db75d5aecece8386abd1110767c044ec20028fed3ca79c89d39fa24db6ae363fade13441a4ac5757b617c7daa9064",
 	"descriptionMd5": "666e52c5d652d100ee9b2cb9e874fb28"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6248,
+	"md5": "b080c380f26074edb69ee259dd6bd552",
+	"sha1": "5a249c8987ad021a80668c15a620a30b0458f5c1",
+	"sha256": "b8f854e9630d2cb984f1d8e779938dca2bc903f4971ab952b1e0fe60b58b4c4d",
+	"sha512": "d72585c6e77947b6d568406e50ce08da729c3dfde718fb2285279690944739ed973ed35b4c0e83c172bf4584a76b981f0b9d08b6e7ab55f5df7149ff0f5e4cd7",
+	"descriptionMd5": "666e52c5d652d100ee9b2cb9e874fb28"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-open-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "2189f0b19db843fed3644d62c14c6c30ff2cf76398266c490b1be9bbe2b3ffbb",
 	"sha512": "54b9a682a09a24eba06b309616f84a60aceca11f7f67e15ba6bb74b7ad268a6f31723261cdf5fde35c0af57fe3bd2a3c44f141589e243f758f480cffe1a3930a",
 	"descriptionMd5": "b9b1249cfe09d57c97aef24f406d00bb"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "bf37ff02254d7f6d07f4d89b513ccd24",
+	"sha1": "be070e55929fc241b6685433e9f995f0422d4409",
+	"sha256": "46551dd00915fa88acb06a82b73c689635d0ea2efb11b88adbddea65c318ce67",
+	"sha512": "1e9e2ff05a0b21fcf19d9ac94ad8cb8ac6811cc1eb3cafa902b63c5e0dfafeb3bf2744dd8dd3ba2acd5a240ed6ae794a4e3488cb3ab61f05dc54a5ca267ca285",
+	"descriptionMd5": "b9b1249cfe09d57c97aef24f406d00bb"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-open-azure.json
@@ -24,4 +24,30 @@
 	"sha256": "6412d3eca75cea898301b38fc4884fbf2c578e082e4a4a97d354c5f47ab47afe",
 	"sha512": "7f0b4b1f59a237dafb582be0785cd5f9ee9d3e9ed9cbb580a917aedb51f0919bfa49f12cc8f674507ac913a8853735d3842fc595de4b0b66bcead84e17f444a7",
 	"descriptionMd5": "31699b36d2030ee28efbeb6af0569a80"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "9cf6784797aa57ea4143fcf0c682db0f",
+	"sha1": "8cda6783bafd7515b563f98445608ffc6ab2393c",
+	"sha256": "0e5cd1b655ce89f71579cb1f2833986766fab9405c275707ffc3bc75fcdf586b",
+	"sha512": "e04ea75f50b411eef09817c2bb686d60ac7a75b8b99bee202e5860cdf3ba4c0357224a31f6da915a48ec6c953ec1d866f15d159f9a6929acb62f34a21a4d8090",
+	"descriptionMd5": "31699b36d2030ee28efbeb6af0569a80"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "9af339b009545ef29243a913962db8de3762e757b1c5bb749eb967d8bfb2bdbb",
 	"sha512": "d12eed34bd5fc0f4dd71b65347df8366daeac7b118ed14c9f6ea2deed85f4a8679a9c27560741c9611651b0fa17b9b0a9cdb3444b75b4a6b3b2d421674e7f5a0",
 	"descriptionMd5": "de70b7b88537c8fc070e20661962884c"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "54fec7492b8e0769b95afb12f33c0e3c",
+	"sha1": "da4a605ba20801f9fb53ca4f7fc71a874d3350ba",
+	"sha256": "791185db1fe1f4487a89e9fee7c24a549dd06b588e87f828f753ebb93e99d2f2",
+	"sha512": "2e69e519b399468b9bbe1191900185b333c6be1729c93d0b090c76d4f18dc1e4d40446b08ac6807fb631c654336b541e8e1841963ba64c8bac54f9550277e797",
+	"descriptionMd5": "de70b7b88537c8fc070e20661962884c"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-azure.json
@@ -24,4 +24,30 @@
 	"sha256": "45ffd45dd30a37e0fd7bc2df9b28c4baec88570115e151e5b3003e2029d24748",
 	"sha512": "b906a73d3c2a689b518a9eb082aef01d793cc84b07c494f3bfca6198e204d7e746a2a4b03b322fc4fcb4b98694072c51ec8381353dddd38d26c27890b2d2012a",
 	"descriptionMd5": "d2774b9f055c4ed0abeeb1b4ad9284e9"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6258,
+	"md5": "09e65a75a2b65f95097dd3caf449b3ad",
+	"sha1": "f64a13f9b89d27490035ed787205256e54cfa58e",
+	"sha256": "6862ee926a674d086ab8974905e859f0af31b6c2ce7408fe3e1215a21aeafe41",
+	"sha512": "80f5313fee3f3c2215739a67f931ede33caaaf33ad84425e61a33665589e749b14eab0a4102e287570049c273186c22b5cd49460be8bcba0d5af5e114afe8cd8",
+	"descriptionMd5": "d2774b9f055c4ed0abeeb1b4ad9284e9"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-open-azure-edge.json
@@ -24,4 +24,30 @@
 	"sha256": "cfefecd4ff1dd564e9fd933da53ba59a8f79fc2ebb17fa6f6f5f63e8ff4ea882",
 	"sha512": "bc83d43cdc1524551c820ca8e6ad4589342951d0de0e5066664dc704b8e9b40ae61d54388626967b02519f2174b1a141233a572ab840ffc5072d406e2919de99",
 	"descriptionMd5": "69306cbe251d80142dc7ee837170e717"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6286,
+	"md5": "1e80045d3caee479569232f958f16975",
+	"sha1": "9d61952fe1c71c3cbc1acad92e8791b53af6ef19",
+	"sha256": "ca3c0cd986ddcfdcefe3c1233862dda9a43394f09a18a08a4acf9ef52dd35137",
+	"sha512": "f2224464af7f0313f7e9b65107a52d94844fa2672d9f04d9c4aae3258fa435985b5e6b6c5ae1b41772fafda74427893c97b49facb8ad892cc6a8733732c2031d",
+	"descriptionMd5": "69306cbe251d80142dc7ee837170e717"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-570-server-open-azure.json
@@ -24,4 +24,30 @@
 	"sha256": "9a988e386683df217c6a6ae041689bb0b2114dca2a734d450d8e05e77846faa3",
 	"sha512": "ee38eb0b32315a84c867352d7258c16c5786917678aadb78edca4692321de6cf9ac14524933fab1015beb808cd7470630cf986413ad6d06db049876ddb46a405",
 	"descriptionMd5": "13d7964dc38917575fef7a9c85924a31"
+},{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "fabc51c354c3a4b1c092e94d217dba1f",
+	"sha1": "f58b942947be5993eccf1864226983e0ea93012c",
+	"sha256": "df11c0a6b78eb208daa9ed085664493d96c0c62fc40736689953c682b6373e3d",
+	"sha512": "4e04c2683ddd3edaa09fadcde55a314c9c856e26b8aa08df2f10a13be87ac991c88950949e35a71aa065095bd29ad517991d84de62654e1d876a49494f62b859",
+	"descriptionMd5": "13d7964dc38917575fef7a9c85924a31"
 }]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-azure-edge.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "629883e91fa0e22b7f43d76fc598924d",
+	"sha1": "af3c8e94a7463b37fd66769469cb30046719a8c4",
+	"sha256": "1f3cb0c11e1d0edef3d27e2971eccca94a706c3c3146c666cb94a32a34cf04e3",
+	"sha512": "b43446aa3137ec8dcc8502ace044981e6032c5dcfe459b701a5b5f062bf3fbbaafa1ac71aec06c49a7f494ee813bf196a6082bd294bf4a071e712025f4a940a2",
+	"descriptionMd5": "9fe81ba2394377026500b82ab34b6c72"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-azure.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6254,
+	"md5": "b40acabcd4fa86a83e2b5bef6a1cdb56",
+	"sha1": "1e51c44802e2efdb4455afd36661eb1d3ecdd629",
+	"sha256": "1731e1472dc6bafa95fe6772152e2fea49b9fc87656af90d4b83086b73d69472",
+	"sha512": "8ae0cbd40f71e8482100943665828bf6f3cd1bb633787904197a0e1656fc00870442ddd378faeea55d016b7f1803c1db6f332a18835de142f4fe9fb9662693fe",
+	"descriptionMd5": "7dd9737eebf90067582d1cb32507f271"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-open-azure-edge.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "c6250856c842989fdfad6cf04fc9645e",
+	"sha1": "41858d320e3c9e82d2c2decf203e0f2325ffbdcf",
+	"sha256": "8ff7e99506a36c32cf9d001ae658b91ec8c44bf7bfb0e0e101fc5c2c70bb5703",
+	"sha512": "8a8b27e286142adac89044a9055d1d330aae9d7615c621895b7f514317bc3cc1df170f09f2414d519b4d55bcb0accad79c01d45165ad3a2d1776d14dfe40c825",
+	"descriptionMd5": "ef703aea4a4cb32d8a95d25782117d88"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-open-azure.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "dd5ec7f48bb575ab789d6e0dd5420955",
+	"sha1": "411a4cdaddee40446ddccc8930e9102056da3583",
+	"sha256": "1e0d7d151a820d2411d2359eea05872e1dd5c20dad793b30f3e512132a78be77",
+	"sha512": "d6b49443372d721b0cd6ee22828e840cbcfc2cd9c2ecddb3ea87bd7d8687c0709fee5a1ae96c16bba3dd0290aff445259dca4142e80cc6ed537965e833634ba5",
+	"descriptionMd5": "61706c6e2411512d1ccbd138506f5ff2"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-azure-edge.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "32a1fe9d62bb4bb2c49253ea2ca0fa79",
+	"sha1": "1e4487ad628c7d6aa883d5b0502dab88ac420627",
+	"sha256": "d60c668bb49c9f6519aa848ccd5195d7607283beeec38e5dcdcac3db226b6f4b",
+	"sha512": "88f41b62e36541423bf762b46a2df1234cb3c99be254136bc41485449f199f0c1e75031dcf72fbbc6600ab9794051c23f48d770ead16f2175c4a5151cf473f7c",
+	"descriptionMd5": "1662e94129c6839e23238f8a609d35d0"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-azure.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6264,
+	"md5": "fc7c4525d5df8feaf525af1e1ecf4006",
+	"sha1": "735b0140e2ae56cfdea95623fc9a428d9cdb1d3f",
+	"sha256": "321c43fa66991bad7587045f491b2ca583c7d86b9c9ac50fb4d2fe0ea2ef36bd",
+	"sha512": "1a872258b46f2aec6d81b34186b0f40acba19cfb9b70bfce2e9a55c5637272106661f021a329edde78f3d2c22b3216aa3a78cb17431fb48b52f1f75629f83542",
+	"descriptionMd5": "3bae6b01517f2c268e2d371d6a3e750b"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-open-azure-edge.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-open-azure-edge.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6286,
+	"md5": "e8607d4c80f0e41daa965866caaa9069",
+	"sha1": "b480b13dd862cdde1545473f2ae596ad3885a961",
+	"sha256": "87ed9e8457f87063c2a38182a5c0c26f3371a14a23ec6e128bfebc0c25203e61",
+	"sha512": "856542ef79178b6c2cacf60666cbaf19da96a803748baea411749104ec074aed5b0378619cb266103b4b12c3160f5c81aee02e40332003b2e05fb1d2769c3434",
+	"descriptionMd5": "3416192f7bea09b635e5570ff9dcf3a7"
+}]

--- a/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-open-azure.json
+++ b/apt/ubuntu-observable/noble/restricted/linux-modules-nvidia-575-server-open-azure.json
@@ -1,0 +1,27 @@
+[{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "61e4dba484e786220f6561ea2a67bdbe",
+	"sha1": "f53db8001c0c3441e555b74b08b33eb7c5633254",
+	"sha256": "79921775172735eebbac179a23bbe1e0eb2d6a2485b5767c95c60697a40da777",
+	"sha512": "304cd271e4512534f20626120ad0df9d73d0e6e108819eef4dd6c10c2d5101e6c35990dcc9a35b2141dfbd17baf3c0caca1ca797b93191b1c4261adb09c05054",
+	"descriptionMd5": "673867bc3303577c505cf5b791542115"
+}]

--- a/apt/ubuntu/noble-updates/main/linux-azure-edge.json
+++ b/apt/ubuntu/noble-updates/main/linux-azure-edge.json
@@ -1,0 +1,33 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-azure-edge",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-image-azure-edge (= 6.11.0-1018.18~24.04.1)",
+		"linux-headers-azure-edge (= 6.11.0-1018.18~24.04.1)",
+		"linux-tools-azure-edge (= 6.11.0-1018.18~24.04.1)",
+		"linux-cloud-tools-azure-edge (= 6.11.0-1018.18~24.04.1)"
+	],
+	"recommends": [
+		"linux-tools-6.11.0-1018-azure",
+		"ubuntu-kernel-accessories"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Complete Linux kernel for Azure systems (vmlinuz).",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-azure-edge_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 1762,
+	"md5": "b64c482f0e30341de68bdf7c8812be0d",
+	"sha1": "b7d7f455fd6695b2ddd914c0722690e4d840585b",
+	"sha256": "db06a849bf7d20f20b99551aa3d74f8f659eeefe1dd79dba3f5589b38f0db5a6",
+	"sha512": "98246329f9e10a93ccce0636b25c65fbf4c7b5588e0ba8f382065e3610ec29e0865f17e50f7ab48378ffef542fdcfab1d737bbaf8856bc1700469631df95f244",
+	"descriptionMd5": "c6a5538486720a06350fb0da8de56a71"
+}

--- a/apt/ubuntu/noble-updates/main/linux-azure.json
+++ b/apt/ubuntu/noble-updates/main/linux-azure.json
@@ -1,0 +1,33 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-azure",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-image-azure (= 6.11.0-1018.18~24.04.1)",
+		"linux-headers-azure (= 6.11.0-1018.18~24.04.1)",
+		"linux-tools-azure (= 6.11.0-1018.18~24.04.1)",
+		"linux-cloud-tools-azure (= 6.11.0-1018.18~24.04.1)"
+	],
+	"recommends": [
+		"linux-tools-6.11.0-1018-azure",
+		"ubuntu-kernel-accessories"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Complete Linux kernel for Azure systems (vmlinuz).",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-azure_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 1758,
+	"md5": "b9185d7d6724bdfd9c3c6d9380b16e32",
+	"sha1": "a201630e1a0c5ed0e5bcd9bd45300028aaf50920",
+	"sha256": "afdcaa84918b55e7a85f18854163d328262d8e1f5e1490993f44c2dcf595d615",
+	"sha512": "0b8fa73aa4e495d938dead027fb4619e4b4b8954118b4a903bc2b44d91816d09c4abdbf1caf6b302baa896d29ba02e5ddbef02223c43f7822fc8e9c8408088b7",
+	"descriptionMd5": "c6a5538486720a06350fb0da8de56a71"
+}

--- a/apt/ubuntu/noble-updates/main/linux-cloud-tools-azure-edge.json
+++ b/apt/ubuntu/noble-updates/main/linux-cloud-tools-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-cloud-tools-azure-edge",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-cloud-tools-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel versioned cloud tools for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-cloud-tools-azure-edge_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2388,
+	"md5": "47d0b3ecc2d42d7334f62fafc7532d1f",
+	"sha1": "15a745036e242048c38c64b195090fc15d735bf7",
+	"sha256": "38e429449946d2e585469318e17079e6bce026db65365a3edeb7cee1dfd00b34",
+	"sha512": "c527e297673c25b449e117d6574bad7967bb695dd561e353ea13cd12213def12fbb70b30f4b81b4542bc3a9cf1b67009ff7b932aeaed1d46ea40beae7e9f04ba",
+	"descriptionMd5": "996a134ced918fe9256d7b32c3a50925"
+}

--- a/apt/ubuntu/noble-updates/main/linux-cloud-tools-azure.json
+++ b/apt/ubuntu/noble-updates/main/linux-cloud-tools-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-cloud-tools-azure",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-cloud-tools-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel versioned cloud tools for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-cloud-tools-azure_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2376,
+	"md5": "3bcc82dd2ba6b30f5a329d5b081be0a0",
+	"sha1": "8b071452f8cae7db602f705f29166ae0c18c47c6",
+	"sha256": "9a7d0f666193a696931ad231f3fd41b62ba1b8717596ad470219abc3c1b286ed",
+	"sha512": "6c047b82106e18b180e40bb846b53350b5372e4dde9e9ed966566dc66157783822254fd7ce3333dc88f0927118177ded00d3e224ed7fbd91c70c326241b35554",
+	"descriptionMd5": "996a134ced918fe9256d7b32c3a50925"
+}

--- a/apt/ubuntu/noble-updates/main/linux-headers-azure-edge.json
+++ b/apt/ubuntu/noble-updates/main/linux-headers-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-headers-azure-edge",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-headers-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel headers for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-headers-azure-edge_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2358,
+	"md5": "e52b35b660544bdce9d994ded743a8f4",
+	"sha1": "1826f97ba4c6ed776456ffb9e7b01590c2e92633",
+	"sha256": "0de713b3dbcbd6410779f651f12140adc551a9a1112acfc7330f0205df8662f0",
+	"sha512": "c857d4847da43af9dbf66375e244f96a5ceed3957620fed47759bdea02326ac868f5f885e11826c969970907596a5a9ef9f9404ffa6aa6fa43e51f173462af0a",
+	"descriptionMd5": "eeb9ab16adc26b5a55752a82472d09ac"
+}

--- a/apt/ubuntu/noble-updates/main/linux-headers-azure.json
+++ b/apt/ubuntu/noble-updates/main/linux-headers-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-headers-azure",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-headers-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel headers for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-headers-azure_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2346,
+	"md5": "a165912b2615782d0b8bcaf7d0668e7e",
+	"sha1": "f78c4c93fcc0246bcea012f12ce4653a048e435e",
+	"sha256": "2433a2e799e7c959d54136e61ebd918ff7e4a19f35ad06dc385c81f7cd7ad267",
+	"sha512": "97bffcefb7c1330a6656745df9ca7e3395791dbcab7221b28b8a0d7e95a0452134dd10c76919c140fe2915c09251029b642866079cd06be913d79b6969099472",
+	"descriptionMd5": "eeb9ab16adc26b5a55752a82472d09ac"
+}

--- a/apt/ubuntu/noble-updates/main/linux-image-azure-edge.json
+++ b/apt/ubuntu/noble-updates/main/linux-image-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-image-azure-edge",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-image-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel image for Azure systems (vmlinuz).",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-image-azure-edge_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2466,
+	"md5": "b4ef91436e10087630838dfb35629499",
+	"sha1": "162937606c1ef474e82af64f4557c87cd212eb91",
+	"sha256": "8c6361006382efb06f7dbf11d0fadae42a5f8c5b0a583f828ab4f08c9dff47e8",
+	"sha512": "ed3b2612785cc5d631088f757f50f277e94623107ea8792554cf704cfab1fc4463ea9f6e9b4cb9fb1cc02027122cfb5728ca1374f6d2d60a9de8ab8a845ca0e1",
+	"descriptionMd5": "7c6ef99d66fe73c5decac014854cc430"
+}

--- a/apt/ubuntu/noble-updates/main/linux-image-azure.json
+++ b/apt/ubuntu/noble-updates/main/linux-image-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-image-azure",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-image-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel image for Azure systems (vmlinuz).",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-image-azure_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2456,
+	"md5": "2a825add5853a7bc18948bc1ef5a3c11",
+	"sha1": "258f308db3ade6b35c3d941f22f720f2b668f2f9",
+	"sha256": "f7538c98096d9f3cd7d22043ae881fe882de8eab43413048aa95fc2d58a23c4a",
+	"sha512": "26458a1e65ae8e44c2e4001c34e107df48b63ee4d1b6d4cc8060ecdd5f3b510b4d04c1dc9b452648c36e669f58f253dd1a2307b2c2aeb34dd4c9a6d857043264",
+	"descriptionMd5": "7c6ef99d66fe73c5decac014854cc430"
+}

--- a/apt/ubuntu/noble-updates/main/linux-modules-extra-azure-edge.json
+++ b/apt/ubuntu/noble-updates/main/linux-modules-extra-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-extra-azure-edge",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-extra-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel extra modules for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-modules-extra-azure-edge_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2376,
+	"md5": "f7932d8d0ab6890a02eaf062b8004b51",
+	"sha1": "12f1b418fdbb8ca8b96912b5633f706c337c0235",
+	"sha256": "4ccd8db59893fcd3049ea44d4df7632fe596675b77e8c646fd15b9eebaad9112",
+	"sha512": "d3e4eb81237049e796782e2457d221a92f43941a91d0dd1f34c6d2e5f02b30e1c1338c1a156753832d3c29a6e27f9bce42a3133a3941a963fdd00610e3baaee5",
+	"descriptionMd5": "e86fbc654b899819b491fe9eee9760a1"
+}

--- a/apt/ubuntu/noble-updates/main/linux-modules-extra-azure.json
+++ b/apt/ubuntu/noble-updates/main/linux-modules-extra-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-extra-azure",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-extra-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel extra modules for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-modules-extra-azure_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2360,
+	"md5": "0d09d1435ba820bbbece3c1fc5eb8907",
+	"sha1": "b92f83bbc4a77fe5528e79d80c16f4b302bb56eb",
+	"sha256": "a66d3b4adfc4410d31fc6c5ead103e9d1c5ed4aaed447652d51b3fd461128099",
+	"sha512": "8c389dc9f7b7fd152855782fe195e81c6f35f8b11feeb63708f31d33781c08faffae0d94e896e58b2d903475f8be4e7e56b07a4816dd85a029079f257dfd177e",
+	"descriptionMd5": "e86fbc654b899819b491fe9eee9760a1"
+}

--- a/apt/ubuntu/noble-updates/main/linux-tools-azure-edge.json
+++ b/apt/ubuntu/noble-updates/main/linux-tools-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-tools-azure-edge",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-tools-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel versioned tools for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-tools-azure-edge_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2378,
+	"md5": "7ffb3df7761ad3aa10fa8ad5cd80f4d7",
+	"sha1": "51252ac92f4b568b661814bff7a46dd8d85256ee",
+	"sha256": "26257093bb6e76c02ad742328bafe3239e9df420ad3113fdab01a146c2129447",
+	"sha512": "260f35959615d18c836e51a91a20b58ebd2e52d0426926437be8347c4c0278fe0869395f50567bbfdb411731393f4d3c3ea57180f39c1dd83451845393282475",
+	"descriptionMd5": "4c6b704fa5b907a56eecc933f84b2a44"
+}

--- a/apt/ubuntu/noble-updates/main/linux-tools-azure.json
+++ b/apt/ubuntu/noble-updates/main/linux-tools-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-tools-azure",
+	"source": "linux-meta-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1",
+	"section": "metapackages",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-tools-6.11.0-1018-azure"
+	],
+	"installedSize": 9,
+	"maintainer": "Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Linux kernel versioned tools for Azure systems.",
+	"filename": "pool/main/l/linux-meta-azure-6.11/linux-tools-azure_6.11.0-1018.18~24.04.1_amd64.deb",
+	"size": 2364,
+	"md5": "607320fff8c686d51f841ba3510c2b6d",
+	"sha1": "1dbb059c2754bb842ebb9e4b5f87eab58344e14b",
+	"sha256": "073d0903c299ad601bdbbefc234e7bd3f237b4be6faed4a20400747d6b082935",
+	"sha512": "9ad4dbe393365448ffe14c5999bdd771a61c36e4fc063247e03cd6e41b932d9132f4f97e736973a16e55c45739e421699a6ff090d579534e2a21aa6951ffb12a",
+	"descriptionMd5": "4c6b704fa5b907a56eecc933f84b2a44"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6192,
+	"md5": "583dda7a1e511fb34f3c27fd58321bb7",
+	"sha1": "3da410ee3bc2d2f2fd5cac9de8da8d52d45e8c67",
+	"sha256": "e2ecc39d6c6f7faf099b3802b16d5ece12644b4e74e58a169bfcdee9862a9248",
+	"sha512": "60afbc772e2b891569f59538eb349f729b87506e88d394fe6e1ff72e01990679937038ba447236a4536a60161847b285c80b6dd1ff0ca81b3c096f3e401a44a5",
+	"descriptionMd5": "1a966ebfced18bd20e35a5e3801b8580"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6188,
+	"md5": "9ac5f1f48088c2615cdad51317704e3c",
+	"sha1": "9c0a0e11709d4b3b24ee3624660e4c8d671c5135",
+	"sha256": "1dec634f7bd0380609ca2feaffa00d9803add2f7af6b2fc0c0e2ae1c9fcbd289",
+	"sha512": "48e56cbe44b76af93cd39e22ed8023421999fe7f9d0602e1273538ac56cd18ae2a79cfbc46ba47f7c13c2eb90cfd394cd3c3d3ec7e55ec43b3d66c854a60624f",
+	"descriptionMd5": "1a966ebfced18bd20e35a5e3801b8580"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-open-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6212,
+	"md5": "edb5c7894e4d8da6bcb9b2a138883c27",
+	"sha1": "1dd4454627fc9738dbd0673e5876c10f1ee32a7f",
+	"sha256": "4bd23d9819c6a78f07f9cf6f7667e30a95197959843a2cedd1eed1b9a18a1c3f",
+	"sha512": "bbd55c12d6ee3932b4fe44310f1a8a54bb64d5c5a80dfec0d978be52b32e71a74b4cfc6b3dd7edbf38ee09d94cbd44689aa5ed5f2c778839edaa772c399896b3",
+	"descriptionMd5": "83e74e97cbe820ad1c52335751c73e4c"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-open-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6196,
+	"md5": "65576ecd5eb1ffd5286b7e18fa8a85d7",
+	"sha1": "f0c0e717c5cdcc519aedff229b8d02a0eebf92a1",
+	"sha256": "be996852ba8a94eb9099564db61ca29111539d6b4fefaa87da4b0f794cbfd7d0",
+	"sha512": "0bf8ec5d7ba32eccb8618b35a31965ce4ba5a97895589c1738319656975576a8cf9add0fc8f2f2ce94ca87ffdd6fb8df8a26c66935f1778a486934fb987bfb5a",
+	"descriptionMd5": "83e74e97cbe820ad1c52335751c73e4c"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6210,
+	"md5": "b94c683b6e36dd8eda89ace7c8ed95f0",
+	"sha1": "fd0e37ed983f16e3c6ed915769793325f1f75c19",
+	"sha256": "98bc350ae5de673938b61d5916d7cb1bf4ddebd630f496c7a79619651290dbd4",
+	"sha512": "6ae2f2ad3fafdad6b9dc4ef0c1a8f95e7ad1e5cd12878d82944466fe5af41ba203c2432a320ffaab5add1b891851c8fb8948846dac7995178ce5efacd560131a",
+	"descriptionMd5": "11968f0fa2fbcbc57df2f70779a446f9"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6198,
+	"md5": "5c1877ad165d583bfc2c71bf13ef48ff",
+	"sha1": "41b693d05a3552fb9f44ed2ff9da969503f80cfe",
+	"sha256": "ac0abd8c4308cff18a6336dc2a4c56ae92451ef561b0fbff4b5d320f2633039b",
+	"sha512": "107fd343ccfa483af641649d3c3f74acab901b3b41badf51b39ba8be6d5a2c2701702106a8de24c1244f6abee4d405fe05ea3a922c1e73360e3906adb70fd79a",
+	"descriptionMd5": "11968f0fa2fbcbc57df2f70779a446f9"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-open-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6222,
+	"md5": "bb50153e2ef80d92862e3a26eefbcfd0",
+	"sha1": "6ba4bddfeefdb2c03a5a677fc5833aa0af61c377",
+	"sha256": "53a4c46964ed23c1fe117ec52e5bb651343c3b19397e7874177ebd4f0018158a",
+	"sha512": "f7f9a221329de0c5fa87a0b23cab0b7834ef2d0a13498aab6403e21c6475eb0ffabcbc0d26b22a43410c1f43f23423ac44165dfb94e1c9c11fbf3f8be78dd8cf",
+	"descriptionMd5": "77b5b4c25bf800e4ceb145692e9a171f"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-525-server-open-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-525-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-525-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-525-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6206,
+	"md5": "45537fd0be4a8f7804b6b1411045f859",
+	"sha1": "72cfea99b651b2b3e0ffb4279ee49fec3011178b",
+	"sha256": "216706dcaf11193c70f989915df91aa7bedf3e45d22ec4dad78523899d4f799e",
+	"sha512": "1c1552cda2c3898f9a7a721ec27cc10f6d85eabc1c62cf6017d163d344357f776e9f9d5a9702b724f2fd55d3bb6c4aa4909ba8b2f6aeb76c5840a4119f064486",
+	"descriptionMd5": "77b5b4c25bf800e4ceb145692e9a171f"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6258,
+	"md5": "7ef2e9ae890eac6b14944a854744bc87",
+	"sha1": "e55c5545e7f89423ae6a300f73bd9fdac0d900d3",
+	"sha256": "fb8f275d3fdb3fdbe61ac315175d770f5ec049d330385a79473fbd812ee1282c",
+	"sha512": "730ce388e7dcf5751ce13b7cb426ec06608e8f162ff5b048786d23d0cd5159655e316c13422e135ee394b696321f365350d56ef6414272cd2fad7625ca37f635",
+	"descriptionMd5": "ba17f60692683b47bba97ee6af14fa93"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6252,
+	"md5": "f3caad04ec7ced8d583211cd6600a12a",
+	"sha1": "54e39a572c88e79fae3ccda72a805dd96ab13c3c",
+	"sha256": "01adabf5544df48665536fb5edbe5774cf0a9220de2b3050fd71a75da8a49e7f",
+	"sha512": "b52b3690d92d9bf03fb74f4ba81f49e2a088039feac29946e29549acf97febd9384f988fa99df575bf2e4789841103f76463a626cd0175ff819c8e5001234de1",
+	"descriptionMd5": "e7b1741d46142078245c051e85ad0e17"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "f12d60de93819dfac038525db75195f1",
+	"sha1": "011af4b159bdf65bb3fa50a212113a5df78e3e92",
+	"sha256": "903664dde167912d2a67b7ff9a80d1ba8d16fd3450238728834ff33daca3e051",
+	"sha512": "e6bba551f085b9656beb032b3a50d3492ad67552c28c5f12a4cd283d89085a6b7be9e17b69c60242d1ffc67c4306b854b20afeab25782a953af129ed1d1ac4f7",
+	"descriptionMd5": "5ba566bace29db7ae101d1da543908d7"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535 (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6252,
+	"md5": "ce1cb21964836b5a9b5312fbd9c10a21",
+	"sha1": "64f2342abf0c51261471789a09605492042ec046",
+	"sha256": "5c5ecf532dc9ef4c3e80197660eb4d9edaec6560b8bc5ca9e1dcd93c5d59e206",
+	"sha512": "d1ed789e508ff9bca8e255553e38f5af70af5c40f612f5cdad197a7ca035e1e95500054f541872fdab89a99016512591edfeddc6bac8af34aec42565f307770a",
+	"descriptionMd5": "badb506668ccd67f84e168b091aa78af"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6272,
+	"md5": "c85a6b324f5ed53f806ff1023f95d6b4",
+	"sha1": "b39698132e4afc96915a76e046d5ae6e352e8e6c",
+	"sha256": "5f63c9d09f5090bf654f718a65aa1568acf187f5312c39c2f8be8ee2e787ae55",
+	"sha512": "e9bb8eb511b56ab61fdc3786bf68e0245d6e07610c563032a4192dd0ced7291c0b37de638591958b9dd1f5512e1bd61b4ed7552c8d9f4d2314ccdba5c4685eaa",
+	"descriptionMd5": "235738b2df75562def82c33a0b77bd55"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6256,
+	"md5": "ef41109d6e056709a8c79fd240d3c95d",
+	"sha1": "23dd0a57d15cdad44030367ea33f11d1e4f95ca1",
+	"sha256": "6b7f8aed106e481dbb6b87b9510dd4ea4b615ea0b2c77ecc4c0a01b1bab9789b",
+	"sha512": "9d0a2f0459bdcab02d4bea46142202896a3a6f3295e44faa0c89db32a9953783f0968bda290d8ce1d3180e486653035b588de6acfad0f390bded39a1b03e87fa",
+	"descriptionMd5": "b471568297983138cd4343bf82f58281"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6282,
+	"md5": "6a90ef165206412b7625c6672ae8bc01",
+	"sha1": "646a5dd046b69c36bafc887c3a3963fe87339f5c",
+	"sha256": "5b8fa2f1c3af19a5a037dbb35f3fd28ea7ed2b430a04481b1cd197bbdf037f94",
+	"sha512": "551a2814488f9ae5a22908d64fd273a5b0ed2ba882daf53cc301c6982826992bcc72ec70232b61f7f90ca989d1f1a62183572beca34b2c465244fa1f5e929e5d",
+	"descriptionMd5": "c30b13c5e23086ea4243ac1ea46deee4"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-535-server-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-535-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-535-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-535-server (>= 535.247.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-535-server-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-535-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "d2d9baf736da7a62ee6f22fb9c7f4eac",
+	"sha1": "a1c946eb5bd006775e33609e90ff5d0643c3bc81",
+	"sha256": "8abbedb402a5125d5f8ff7ca227f497394db5eb7194cae86336fc8b89cc2e44c",
+	"sha512": "8efc646add4302b6c9006bb29fe429f35659d68ce87a63bae9fb5c7f3f3eae57e80f54e10e2a0e898e7e8fffaf1deb2d3a6f65d81435e87039429d7801f457c9",
+	"descriptionMd5": "ac9f68bfe3ce8d821cec0a5cbce25afa"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6192,
+	"md5": "85e820bbe71971a42654374fcdf9b839",
+	"sha1": "f3b4307a3a6787fc0020c6043d861159da2126cc",
+	"sha256": "15f5aacf30c3ee90bc446ba1b89016c79b79d575aee460c76c3bf40df4f39bcb",
+	"sha512": "211dd7ea01f233efef7e323f799b8cf0f7851e4317bf23957554029402b4f3d2117b9519d1bb0e4627cea5eb5a112d6d1f687e2bb10d65a9c54b9f5b9789be2e",
+	"descriptionMd5": "4a16566af1e380d4e9aa573e84c9d827"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545 for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6186,
+	"md5": "77436c04861d85846e330e2305dfa151",
+	"sha1": "f3306577a0f0a7f228cae30a36b0f2ece71f3b07",
+	"sha256": "ee4065180f0b3821d2f23efbd85b8132454e0f23f2ae7030d11f248311f2ecc9",
+	"sha512": "a91853d5423a87c80fa20da240151093089d07a5abd9a2d31d8d09f67e57643f852c6614b909101ab0caccae32cc7446b57d6f37bd869ba06e22c284da0dc500",
+	"descriptionMd5": "4a16566af1e380d4e9aa573e84c9d827"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-open-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/oldlibs",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6210,
+	"md5": "5af948558d1a1be1dcf9a32c2d02abb2",
+	"sha1": "818d2f3adf5d9244a6d7ab92aeec1acd2a85228e",
+	"sha256": "7695b81b5f02efd5cccc9d52234d156f7ce0a6c100e229a192f9679ed1edef9c",
+	"sha512": "dc480ca3a197fe37433bca2f586ac969035e07ff54287ed7663517295e765edf9b387d8a3c4e51385c2d8ce6fd233862edcac3b0f4daa6c414d6a87576fa2099",
+	"descriptionMd5": "25897d1311a34315523732010ffb4936"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-545-open-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-545-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-545-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-545-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6198,
+	"md5": "72339e4f28267e004cbd4d981069fa93",
+	"sha1": "1c5b62c8958409e1a9f0740c796377760856ba3a",
+	"sha256": "83b74c8eb0b9ba46a58cbef03130bbbb2a9a449829280db8156e5f2d764268a3",
+	"sha512": "7fc0c96ebeeb21a5c8090085464cf124e18ce767e8e16d9af66e3142a476c8b75333fe1720b9cf49b0bf5523f49cab60051b13606b5da66cdd7c8f477fe6cd62",
+	"descriptionMd5": "25897d1311a34315523732010ffb4936"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6258,
+	"md5": "518115966b152295bf524447f36661cb",
+	"sha1": "aac4bed74906f890e0898078173c42b8d1b3e952",
+	"sha256": "3843a08b826a41d190fa6cae329f7a12bda866bc36d2078a1dacfb06f82e0f77",
+	"sha512": "203696f4533ffcb8e7c4850e109abdc46d1bac52c85831d52e0498ebcb911ac265a141e3b38cf0a9a60fa8f4bab615f458f295175667ed0621b0df46d400bd78",
+	"descriptionMd5": "07790e32d063c4c88a17f5393725225e"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6250,
+	"md5": "393b34692d346b1b4c7450d6d39d6551",
+	"sha1": "753215e69e71fdc645f7d43e37dfc14181ce2006",
+	"sha256": "3646e9f69d5d4affe7bd54c441e1f9231d0a4955a474e385eba721e6160478a2",
+	"sha512": "75b65dc491e4ff2c253537a66ea555d96574f963e430fd3f97f1ca26d6a21609b75c674442e39e9c60d72a4b051cbf23c6822eebd6073eb76aad1dc0114c6513",
+	"descriptionMd5": "88662ddf4d9b38672437027f5d9c3ca2"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "24bad75960c2b973e4409d8882514faf",
+	"sha1": "e9a94315ef854d7f7229e10f93581d05a97ce11c",
+	"sha256": "bb82964f493700ae9d36243c3237cce90b17304614c9616d6384aa56ef598d07",
+	"sha512": "45978ea3eb618c21df0159b64a72ebef7bb9a04d0a204c567d62ee19d8602c7c67cd41baf2a142ae3aa8c6c30b0870caed9f203b1999436cdad48fc2ee676d5b",
+	"descriptionMd5": "6f9cd416f4f44c6d0074a665224d8abc"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-550-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-550 (>= 550.163.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "e445c9747f6925ab26043b20084caf8c",
+	"sha1": "44ffc38f240534e671838ae446ca9e261a1b1524",
+	"sha256": "8f14a27d57279b240445617422b20e7c10d658c4a315ccbc64912df742a53398",
+	"sha512": "2efff4bb2c4fa7d6dab61be1d3add11772940188f36965258ae0a63ae99d8960be1c5e9c34b92970b15a3fb96f559823c06706bf20baa55274ab47ba51ecad69",
+	"descriptionMd5": "5b71184ce4017a233c641fa6143f0ab7"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6212,
+	"md5": "85cbeec700940b45d874c493beaa7c13",
+	"sha1": "91b5c538add3bc68470d0d59b0f30d24392ba332",
+	"sha256": "ff9add551de28ed09020568a390fd5cd0fbe4678a10eb78ed95d71d65af9eafe",
+	"sha512": "fca41fd19f2355c8bd4a96a7bdeb7bf45af31d26f79b5b74e7ba5e8428201196b8a5ae6ce56bbefcc223e4d5a1a6cff9694fc20c629c9e5569cca736105b19f7",
+	"descriptionMd5": "8f5e9e4b3ff3bbc23f536186b3008a1c"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6196,
+	"md5": "6995dd4a0d00dfdeba0a3a5d786114dd",
+	"sha1": "cf333ed808d680af56fdda007cc4091eec377906",
+	"sha256": "01e83fd40b5e38d981f1311a5812934a9f7052caa67f064223c85975254f134e",
+	"sha512": "08c9d454e3a3489ceda3f633622bdbf96867176de9aa166f524307dcb1c8ad4d1c1fd0fec80d1f2eec019383177720450945df8a8ba80b12cfa9daffd2ac7966",
+	"descriptionMd5": "8f5e9e4b3ff3bbc23f536186b3008a1c"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-open-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6224,
+	"md5": "492ba20ada71160a26dbabbcc9137008",
+	"sha1": "1f1b18d96cdeda11fa989e9fcf2be28f459446e7",
+	"sha256": "2e60fbb8f7edc9c18d625434d1bef3b86673611c8befbaf6b524b0bb0c175333",
+	"sha512": "de10fce3567f0ebc2f2bf0141b42950b4d3ca3691431606711e2f2526af00ff06283cd752e37358016940178c9ae94c242544bbf19a1501beed56bc7cfc5c973",
+	"descriptionMd5": "8f1837212f159be2ae3215f13992aeac"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-550-server-open-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-550-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-550-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-550-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6206,
+	"md5": "ef95f6f06f7f9a25c51eeff388a2dafc",
+	"sha1": "f3bf4cb202d89ed822c02b31d737ed57b62ed49c",
+	"sha256": "35e8acb34fff046a021dcfcb65b073d28f8fad13660cb16b5506add78ecae95e",
+	"sha512": "2267abab7ce78c08bbeb5af52f43413658db4e8acc11438814a0e040a3e66491d8cdd3f65509992c8107d88b602932ed05ce372f147e7372a4fe5b4b93df71c9",
+	"descriptionMd5": "8f1837212f159be2ae3215f13992aeac"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6212,
+	"md5": "6d5f3655973de12ff6edca07e00b46de",
+	"sha1": "6a683c34be6e9a77b2960e4411960c23d87fc792",
+	"sha256": "5ed21b550cf134fe2fa525c2c626dd9a2d833332049f685ac3c74fb54e4dfda7",
+	"sha512": "d7f7cfc5f98c5d8348e27952f2460795eeacf5062e873ca0d7da2fdd6d5dda2c461eea68fb75e4152cd07393144f9dbb7b64953254ae277919c5ea1bef911bd1",
+	"descriptionMd5": "ec35a657849543adb1634fa05315385a"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6198,
+	"md5": "0089e68e61f83d2106bb7b540ef08707",
+	"sha1": "c3af89a04487be616d5e3f0f02fc75a337f20787",
+	"sha256": "04ed6b31c5b8750e2a672066c4681d96ae9db0024acb83e5c7e68ff005546c3e",
+	"sha512": "25c3701dff9bcf7be418ed197256596461f00c2c823e2f505eab64c2624e4b2778462c511ced399e70edbf6584a272312d9b44a59560d36d6d44253e6f175672",
+	"descriptionMd5": "ec35a657849543adb1634fa05315385a"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-open-azure-edge.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure-edge"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6228,
+	"md5": "e26f70922e12293fa17bff7cc886457c",
+	"sha1": "f95914f4881d57f9866b9d3fa038cf7bbbc58e9a",
+	"sha256": "0587dea3e1d41ba6f875d8542fcfea6e8d2bd4e2eb5d5b84345aa35b50930520",
+	"sha512": "4cf046ce638be033eb34a98323c7d44b3f15c5776b95e0a99964087bbc35628ea328ed55008c38b6fdd6a1ef75c678252d245d763299ae4186dbc4cdc82e404c",
+	"descriptionMd5": "ea3a481c0c39cd40fdcc64046808c6c8"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-565-server-open-azure.json
@@ -1,0 +1,26 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-565-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-azure"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-565-server-open for the azure flavour (dummy transitional package)",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-565-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6208,
+	"md5": "08f7daff274595bdc1497ee3abfa274c",
+	"sha1": "da8c4b828efbd9e38fcc400e1f894059bf2ec2b3",
+	"sha256": "ef52216bb5ebbaeefde94fb08b736fb0f27ababf826c75a665a35e05fc768e18",
+	"sha512": "1ceb177f8f4bcf6c330b0795d3dbe2c4aed0381a87b5f687e0d7426f868b9b0d2b42228a04a40e3de924e1736083374401e2d4535027dbdf889d45f2c967d9de",
+	"descriptionMd5": "ea3a481c0c39cd40fdcc64046808c6c8"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6254,
+	"md5": "c8e4a726837068b339363fe63b370f05",
+	"sha1": "dc2d7686f62c42b254a0aae79a48244860ce240f",
+	"sha256": "5961569c73e55f53f71ae188446942e036f00ec81823c7dfe73d249220c37b29",
+	"sha512": "72c0cc5c773f6d440c747c3648c5136ffb02649221d00e93df3a03c2193991c6ef2a645620e59122d07a787668d1a35ab0138af9339f3165d9676e67cf27b57b",
+	"descriptionMd5": "5ef022f18c9b59ae406a9e2938c1dae6"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6248,
+	"md5": "b080c380f26074edb69ee259dd6bd552",
+	"sha1": "5a249c8987ad021a80668c15a620a30b0458f5c1",
+	"sha256": "b8f854e9630d2cb984f1d8e779938dca2bc903f4971ab952b1e0fe60b58b4c4d",
+	"sha512": "d72585c6e77947b6d568406e50ce08da729c3dfde718fb2285279690944739ed973ed35b4c0e83c172bf4584a76b981f0b9d08b6e7ab55f5df7149ff0f5e4cd7",
+	"descriptionMd5": "666e52c5d652d100ee9b2cb9e874fb28"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "bf37ff02254d7f6d07f4d89b513ccd24",
+	"sha1": "be070e55929fc241b6685433e9f995f0422d4409",
+	"sha256": "46551dd00915fa88acb06a82b73c689635d0ea2efb11b88adbddea65c318ce67",
+	"sha512": "1e9e2ff05a0b21fcf19d9ac94ad8cb8ac6811cc1eb3cafa902b63c5e0dfafeb3bf2744dd8dd3ba2acd5a240ed6ae794a4e3488cb3ab61f05dc54a5ca267ca285",
+	"descriptionMd5": "b9b1249cfe09d57c97aef24f406d00bb"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570 (>= 570.169)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "9cf6784797aa57ea4143fcf0c682db0f",
+	"sha1": "8cda6783bafd7515b563f98445608ffc6ab2393c",
+	"sha256": "0e5cd1b655ce89f71579cb1f2833986766fab9405c275707ffc3bc75fcdf586b",
+	"sha512": "e04ea75f50b411eef09817c2bb686d60ac7a75b8b99bee202e5860cdf3ba4c0357224a31f6da915a48ec6c953ec1d866f15d159f9a6929acb62f34a21a4d8090",
+	"descriptionMd5": "31699b36d2030ee28efbeb6af0569a80"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "54fec7492b8e0769b95afb12f33c0e3c",
+	"sha1": "da4a605ba20801f9fb53ca4f7fc71a874d3350ba",
+	"sha256": "791185db1fe1f4487a89e9fee7c24a549dd06b588e87f828f753ebb93e99d2f2",
+	"sha512": "2e69e519b399468b9bbe1191900185b333c6be1729c93d0b090c76d4f18dc1e4d40446b08ac6807fb631c654336b541e8e1841963ba64c8bac54f9550277e797",
+	"descriptionMd5": "de70b7b88537c8fc070e20661962884c"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6258,
+	"md5": "09e65a75a2b65f95097dd3caf449b3ad",
+	"sha1": "f64a13f9b89d27490035ed787205256e54cfa58e",
+	"sha256": "6862ee926a674d086ab8974905e859f0af31b6c2ce7408fe3e1215a21aeafe41",
+	"sha512": "80f5313fee3f3c2215739a67f931ede33caaaf33ad84425e61a33665589e749b14eab0a4102e287570049c273186c22b5cd49460be8bcba0d5af5e114afe8cd8",
+	"descriptionMd5": "d2774b9f055c4ed0abeeb1b4ad9284e9"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6286,
+	"md5": "1e80045d3caee479569232f958f16975",
+	"sha1": "9d61952fe1c71c3cbc1acad92e8791b53af6ef19",
+	"sha256": "ca3c0cd986ddcfdcefe3c1233862dda9a43394f09a18a08a4acf9ef52dd35137",
+	"sha512": "f2224464af7f0313f7e9b65107a52d94844fa2672d9f04d9c4aae3258fa435985b5e6b6c5ae1b41772fafda74427893c97b49facb8ad892cc6a8733732c2031d",
+	"descriptionMd5": "69306cbe251d80142dc7ee837170e717"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-570-server-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-570-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-570-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-570-server (>= 570.158.01)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-570-server-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-570-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6274,
+	"md5": "fabc51c354c3a4b1c092e94d217dba1f",
+	"sha1": "f58b942947be5993eccf1864226983e0ea93012c",
+	"sha256": "df11c0a6b78eb208daa9ed085664493d96c0c62fc40736689953c682b6373e3d",
+	"sha512": "4e04c2683ddd3edaa09fadcde55a314c9c856e26b8aa08df2f10a13be87ac991c88950949e35a71aa065095bd29ad517991d84de62654e1d876a49494f62b859",
+	"descriptionMd5": "13d7964dc38917575fef7a9c85924a31"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575 for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "629883e91fa0e22b7f43d76fc598924d",
+	"sha1": "af3c8e94a7463b37fd66769469cb30046719a8c4",
+	"sha256": "1f3cb0c11e1d0edef3d27e2971eccca94a706c3c3146c666cb94a32a34cf04e3",
+	"sha512": "b43446aa3137ec8dcc8502ace044981e6032c5dcfe459b701a5b5f062bf3fbbaafa1ac71aec06c49a7f494ee813bf196a6082bd294bf4a071e712025f4a940a2",
+	"descriptionMd5": "9fe81ba2394377026500b82ab34b6c72"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575 for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6254,
+	"md5": "b40acabcd4fa86a83e2b5bef6a1cdb56",
+	"sha1": "1e51c44802e2efdb4455afd36661eb1d3ecdd629",
+	"sha256": "1731e1472dc6bafa95fe6772152e2fea49b9fc87656af90d4b83086b73d69472",
+	"sha512": "8ae0cbd40f71e8482100943665828bf6f3cd1bb633787904197a0e1656fc00870442ddd378faeea55d016b7f1803c1db6f332a18835de142f4fe9fb9662693fe",
+	"descriptionMd5": "7dd9737eebf90067582d1cb32507f271"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "c6250856c842989fdfad6cf04fc9645e",
+	"sha1": "41858d320e3c9e82d2c2decf203e0f2325ffbdcf",
+	"sha256": "8ff7e99506a36c32cf9d001ae658b91ec8c44bf7bfb0e0e101fc5c2c70bb5703",
+	"sha512": "8a8b27e286142adac89044a9055d1d330aae9d7615c621895b7f514317bc3cc1df170f09f2414d519b4d55bcb0accad79c01d45165ad3a2d1776d14dfe40c825",
+	"descriptionMd5": "ef703aea4a4cb32d8a95d25782117d88"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575 (>= 575.64.03)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6260,
+	"md5": "dd5ec7f48bb575ab789d6e0dd5420955",
+	"sha1": "411a4cdaddee40446ddccc8930e9102056da3583",
+	"sha256": "1e0d7d151a820d2411d2359eea05872e1dd5c20dad793b30f3e512132a78be77",
+	"sha512": "d6b49443372d721b0cd6ee22828e840cbcfc2cd9c2ecddb3ea87bd7d8687c0709fee5a1ae96c16bba3dd0290aff445259dca4142e80cc6ed537965e833634ba5",
+	"descriptionMd5": "61706c6e2411512d1ccbd138506f5ff2"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "32a1fe9d62bb4bb2c49253ea2ca0fa79",
+	"sha1": "1e4487ad628c7d6aa883d5b0502dab88ac420627",
+	"sha256": "d60c668bb49c9f6519aa848ccd5195d7607283beeec38e5dcdcac3db226b6f4b",
+	"sha512": "88f41b62e36541423bf762b46a2df1234cb3c99be254136bc41485449f199f0c1e75031dcf72fbbc6600ab9794051c23f48d770ead16f2175c4a5151cf473f7c",
+	"descriptionMd5": "1662e94129c6839e23238f8a609d35d0"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6264,
+	"md5": "fc7c4525d5df8feaf525af1e1ecf4006",
+	"sha1": "735b0140e2ae56cfdea95623fc9a428d9cdb1d3f",
+	"sha256": "321c43fa66991bad7587045f491b2ca583c7d86b9c9ac50fb4d2fe0ea2ef36bd",
+	"sha512": "1a872258b46f2aec6d81b34186b0f40acba19cfb9b70bfce2e9a55c5637272106661f021a329edde78f3d2c22b3216aa3a78cb17431fb48b52f1f75629f83542",
+	"descriptionMd5": "3bae6b01517f2c268e2d371d6a3e750b"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-open-azure-edge.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-open-azure-edge.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-open-azure-edge",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server-open for the azure-edge flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-open-azure-edge_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6286,
+	"md5": "e8607d4c80f0e41daa965866caaa9069",
+	"sha1": "b480b13dd862cdde1545473f2ae596ad3885a961",
+	"sha256": "87ed9e8457f87063c2a38182a5c0c26f3371a14a23ec6e128bfebc0c25203e61",
+	"sha512": "856542ef79178b6c2cacf60666cbaf19da96a803748baea411749104ec074aed5b0378619cb266103b4b12c3160f5c81aee02e40332003b2e05fb1d2769c3434",
+	"descriptionMd5": "3416192f7bea09b635e5570ff9dcf3a7"
+}

--- a/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-open-azure.json
+++ b/apt/ubuntu/noble-updates/restricted/linux-modules-nvidia-575-server-open-azure.json
@@ -1,0 +1,27 @@
+{
+	"raw": {},
+	"required": [
+		"Filename",
+		"Size"
+	],
+	"package": "linux-modules-nvidia-575-server-open-azure",
+	"source": "linux-restricted-modules-azure-6.11",
+	"version": "6.11.0-1018.18~24.04.1+2",
+	"section": "restricted/kernel",
+	"priority": "optional",
+	"architecture": "amd64",
+	"depends": [
+		"linux-modules-nvidia-575-server-open-6.11.0-1018-azure (= 6.11.0-1018.18~24.04.1+2)",
+		"nvidia-kernel-common-575-server (>= 575.57.08)"
+	],
+	"installedSize": 18,
+	"maintainer": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+	"description": "Extra drivers for nvidia-575-server-open for the azure flavour",
+	"filename": "pool/restricted/l/linux-restricted-modules-azure-6.11/linux-modules-nvidia-575-server-open-azure_6.11.0-1018.18~24.04.1+2_amd64.deb",
+	"size": 6276,
+	"md5": "61e4dba484e786220f6561ea2a67bdbe",
+	"sha1": "f53db8001c0c3441e555b74b08b33eb7c5633254",
+	"sha256": "79921775172735eebbac179a23bbe1e0eb2d6a2485b5767c95c60697a40da777",
+	"sha512": "304cd271e4512534f20626120ad0df9d73d0e6e108819eef4dd6c10c2d5101e6c35990dcc9a35b2141dfbd17baf3c0caca1ca797b93191b1c4261adb09c05054",
+	"descriptionMd5": "673867bc3303577c505cf5b791542115"
+}


### PR DESCRIPTION
## Metadata Log
```shell
npm warn exec The following package was not found and will be installed: @apt-repositories/generator@2.8.0
Generating tasks...
Generating metadata...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-backports/main/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-backports/universe/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/main/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/multiverse/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/restricted/binary-amd64/Packages.xz'...
  + Written 66 package metadata files for component 'ubuntu/bionic-backports/universe' to 'apt/ubuntu/bionic-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/universe/binary-amd64/Packages.xz'...
  + Written 96 package metadata files for component 'ubuntu/bionic-security/multiverse' to 'apt/ubuntu/bionic-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/binary-amd64/Packages.xz'...
  + Written 231 package metadata files for component 'ubuntu/bionic-backports/main' to 'apt/ubuntu/bionic-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 123 package metadata files for component 'ubuntu/bionic-updates/multiverse' to 'apt/ubuntu/bionic-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/restricted/binary-amd64/Packages.xz'...
  + Written 6.423K package metadata files for component 'ubuntu/bionic-security/universe' to 'apt/ubuntu/bionic-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/binary-amd64/Packages.xz'...
  + Written 7.342K package metadata files for component 'ubuntu/bionic-security/restricted' to 'apt/ubuntu/bionic-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/main/binary-amd64/Packages.xz'...
  + Written 7.5K package metadata files for component 'ubuntu/bionic-updates/restricted' to 'apt/ubuntu/bionic-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/multiverse/binary-amd64/Packages.xz'...
  + Written 830 package metadata files for component 'ubuntu/bionic/multiverse' to 'apt/ubuntu/bionic/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/restricted/binary-amd64/Packages.xz'...
  + Written 50 package metadata files for component 'ubuntu/bionic/restricted' to 'apt/ubuntu/bionic/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/Packages.xz'...
  + Written 14.99K package metadata files for component 'ubuntu/bionic-security/main' to 'apt/ubuntu/bionic-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-backports/main/binary-amd64/Packages.xz'...
  + Written 198 package metadata files for component 'ubuntu/focal-backports/main' to 'apt/ubuntu/focal-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-backports/universe/binary-amd64/Packages.xz'...
  + Written 6.391K package metadata files for component 'ubuntu/bionic/main' to 'apt/ubuntu/bionic/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/main/binary-amd64/Packages.xz'...
  + Written 90 package metadata files for component 'ubuntu/focal-backports/universe' to 'apt/ubuntu/focal-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/multiverse/binary-amd64/Packages.xz'...
  + Written 116 package metadata files for component 'ubuntu/focal-security/multiverse' to 'apt/ubuntu/focal-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/restricted/binary-amd64/Packages.xz'...
  + Written 9.35K package metadata files for component 'ubuntu/bionic-updates/universe' to 'apt/ubuntu/bionic-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/universe/binary-amd64/Packages.xz'...
  + Written 16.566K package metadata files for component 'ubuntu/bionic-updates/main' to 'apt/ubuntu/bionic-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/main/binary-amd64/Packages.xz'...
  + Written 5.056K package metadata files for component 'ubuntu/focal-security/universe' to 'apt/ubuntu/focal-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 130 package metadata files for component 'ubuntu/focal-updates/multiverse' to 'apt/ubuntu/focal-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/restricted/binary-amd64/Packages.xz'...
  + Written 20.027K package metadata files for component 'ubuntu/focal-security/main' to 'apt/ubuntu/focal-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/universe/binary-amd64/Packages.xz'...
  + Written 20.926K package metadata files for component 'ubuntu/focal-security/restricted' to 'apt/ubuntu/focal-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64/Packages.xz'...
  + Written 21.984K package metadata files for component 'ubuntu/focal-updates/main' to 'apt/ubuntu/focal-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/multiverse/binary-amd64/Packages.xz'...
  + Written 813 package metadata files for component 'ubuntu/focal/multiverse' to 'apt/ubuntu/focal/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/restricted/binary-amd64/Packages.xz'...
  + Written 143 package metadata files for component 'ubuntu/focal/restricted' to 'apt/ubuntu/focal/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.xz'...
  + Written 6.09K package metadata files for component 'ubuntu/focal/main' to 'apt/ubuntu/focal/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-backports/main/binary-amd64/Packages.xz'...
  + Written 21.779K package metadata files for component 'ubuntu/focal-updates/restricted' to 'apt/ubuntu/focal-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-backports/universe/binary-amd64/Packages.xz'...
  + Written 336 package metadata files for component 'ubuntu/jammy-backports/main' to 'apt/ubuntu/jammy-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/main/binary-amd64/Packages.xz'...
  + Written 121 package metadata files for component 'ubuntu/jammy-backports/universe' to 'apt/ubuntu/jammy-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/multiverse/binary-amd64/Packages.xz'...
  + Written 5.97K package metadata files for component 'ubuntu/focal-updates/universe' to 'apt/ubuntu/focal-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/restricted/binary-amd64/Packages.xz'...
  + Written 214 package metadata files for component 'ubuntu/jammy-security/multiverse' to 'apt/ubuntu/jammy-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/universe/binary-amd64/Packages.xz'...
  + Written 4.75K package metadata files for component 'ubuntu/jammy-security/universe' to 'apt/ubuntu/jammy-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/Packages.xz'...
  + Written 14.456K package metadata files for component 'ubuntu/jammy-security/main' to 'apt/ubuntu/jammy-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 291 package metadata files for component 'ubuntu/jammy-updates/multiverse' to 'apt/ubuntu/jammy-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/restricted/binary-amd64/Packages.xz'...
  + Written 53.596K package metadata files for component 'ubuntu/bionic/universe' to 'apt/ubuntu/bionic/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/universe/binary-amd64/Packages.xz'...
  + Written 5.693K package metadata files for component 'ubuntu/jammy-updates/universe' to 'apt/ubuntu/jammy-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64/Packages.xz'...
  + Written 15.625K package metadata files for component 'ubuntu/jammy-updates/main' to 'apt/ubuntu/jammy-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/multiverse/binary-amd64/Packages.xz'...
  + Written 22.876K package metadata files for component 'ubuntu/jammy-security/restricted' to 'apt/ubuntu/jammy-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/restricted/binary-amd64/Packages.xz'...
  + Written 686 package metadata files for component 'ubuntu/jammy/restricted' to 'apt/ubuntu/jammy/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/universe/binary-amd64/Packages.xz'...
  + Written 881 package metadata files for component 'ubuntu/jammy/multiverse' to 'apt/ubuntu/jammy/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-backports/main/binary-amd64/Packages.xz'...
  + Written 173 package metadata files for component 'ubuntu/noble-backports/main' to 'apt/ubuntu/noble-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-backports/universe/binary-amd64/Packages.xz'...
  + Written 115 package metadata files for component 'ubuntu/noble-backports/universe' to 'apt/ubuntu/noble-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/Packages.xz'...
  + Written 6.09K package metadata files for component 'ubuntu/jammy/main' to 'apt/ubuntu/jammy/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/multiverse/binary-amd64/Packages.xz'...
  + Written 80 package metadata files for component 'ubuntu/noble-security/multiverse' to 'apt/ubuntu/noble-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/restricted/binary-amd64/Packages.xz'...
  + Written 5.775K package metadata files for component 'ubuntu/noble-security/main' to 'apt/ubuntu/noble-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/Packages.xz'...
  + Written 4.174K package metadata files for component 'ubuntu/noble-security/universe' to 'apt/ubuntu/noble-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/Packages.xz'...
  + Written 9.047K package metadata files for component 'ubuntu/noble-security/restricted' to 'apt/ubuntu/noble-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 148 package metadata files for component 'ubuntu/noble-updates/multiverse' to 'apt/ubuntu/noble-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/restricted/binary-amd64/Packages.xz'...
  + Written 23.719K package metadata files for component 'ubuntu/jammy-updates/restricted' to 'apt/ubuntu/jammy-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/Packages.xz'...
  + Written 6.989K package metadata files for component 'ubuntu/noble-updates/main' to 'apt/ubuntu/noble-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/Packages.xz'...
  + Written 5.165K package metadata files for component 'ubuntu/noble-updates/universe' to 'apt/ubuntu/noble-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/multiverse/binary-amd64/Packages.xz'...
  + Written 53.206K package metadata files for component 'ubuntu/focal/universe' to 'apt/ubuntu/focal/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/restricted/binary-amd64/Packages.xz'...
  + Written 1.154K package metadata files for component 'ubuntu/noble/multiverse' to 'apt/ubuntu/noble/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/Packages.xz'...
  + Written 492 package metadata files for component 'ubuntu/noble/restricted' to 'apt/ubuntu/noble/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-security/main/binary-amd64/Packages.xz'...
  + Written 9.58K package metadata files for component 'ubuntu/noble-updates/restricted' to 'apt/ubuntu/noble-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-security/multiverse/binary-amd64/Packages.xz'...
  + Written 817 package metadata files for component 'ubuntu/plucky-security/main' to 'apt/ubuntu/plucky-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-security/restricted/binary-amd64/Packages.xz'...
  + Written 57 package metadata files for component 'ubuntu/plucky-security/multiverse' to 'apt/ubuntu/plucky-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-security/universe/binary-amd64/Packages.xz'...
  + Written 798 package metadata files for component 'ubuntu/plucky-security/restricted' to 'apt/ubuntu/plucky-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-updates/main/binary-amd64/Packages.xz'...
  + Written 459 package metadata files for component 'ubuntu/plucky-security/universe' to 'apt/ubuntu/plucky-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 110 package metadata files for component 'ubuntu/plucky-updates/multiverse' to 'apt/ubuntu/plucky-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-updates/restricted/binary-amd64/Packages.xz'...
  + Written 6.099K package metadata files for component 'ubuntu/noble/main' to 'apt/ubuntu/noble/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky-updates/universe/binary-amd64/Packages.xz'...
  + Written 1.233K package metadata files for component 'ubuntu/plucky-updates/main' to 'apt/ubuntu/plucky-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky/main/binary-amd64/Packages.xz'...
  + Written 819 package metadata files for component 'ubuntu/plucky-updates/universe' to 'apt/ubuntu/plucky-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky/multiverse/binary-amd64/Packages.xz'...
  + Written 891 package metadata files for component 'ubuntu/plucky-updates/restricted' to 'apt/ubuntu/plucky-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky/restricted/binary-amd64/Packages.xz'...
  + Written 264 package metadata files for component 'ubuntu/plucky/restricted' to 'apt/ubuntu/plucky/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/plucky/universe/binary-amd64/Packages.xz'...
  + Written 1.095K package metadata files for component 'ubuntu/plucky/multiverse' to 'apt/ubuntu/plucky/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/main/binary-amd64/Packages.gz'. (20kB)
  + Written 63 package metadata files for component 'ubuntu/trusty-backports/main' to 'apt/ubuntu/trusty-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/multiverse/binary-amd64/Packages.gz'. (1.74kB)
  + Written 4 package metadata files for component 'ubuntu/trusty-backports/multiverse' to 'apt/ubuntu/trusty-backports/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/universe/binary-amd64/Packages.gz'. (72.8kB)
  + Written 244 package metadata files for component 'ubuntu/trusty-backports/universe' to 'apt/ubuntu/trusty-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/main/binary-amd64/Packages.gz'. (878kB)
  + Written 3.22K package metadata files for component 'ubuntu/trusty-security/main' to 'apt/ubuntu/trusty-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/multiverse/binary-amd64/Packages.gz'...
  + Written 6.323K package metadata files for component 'ubuntu/plucky/main' to 'apt/ubuntu/plucky/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/restricted/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/multiverse/binary-amd64/Packages.gz'. (6.13kB)
  + Written 17 package metadata files for component 'ubuntu/trusty-security/multiverse' to 'apt/ubuntu/trusty-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/restricted/binary-amd64/Packages.gz'. (24.6kB)
  + Written 77 package metadata files for component 'ubuntu/trusty-security/restricted' to 'apt/ubuntu/trusty-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/binary-amd64/Packages.gz'. (1.46MB)
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/universe/binary-amd64/Packages.gz'. (489kB)
  + Written 1.632K package metadata files for component 'ubuntu/trusty-security/universe' to 'apt/ubuntu/trusty-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/multiverse/binary-amd64/Packages.gz'. (21.7kB)
  + Written 65 package metadata files for component 'ubuntu/trusty-updates/multiverse' to 'apt/ubuntu/trusty-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/restricted/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/restricted/binary-amd64/Packages.gz'. (28.8kB)
  + Written 86 package metadata files for component 'ubuntu/trusty-updates/restricted' to 'apt/ubuntu/trusty-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/universe/binary-amd64/Packages.gz'. (883kB)
  + Written 5.434K package metadata files for component 'ubuntu/trusty-updates/main' to 'apt/ubuntu/trusty-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/Packages.gz'. (1.74MB)
  + Written 2.91K package metadata files for component 'ubuntu/trusty-updates/universe' to 'apt/ubuntu/trusty-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/multiverse/binary-amd64/Packages.gz'. (169kB)
  + Written 741 package metadata files for component 'ubuntu/trusty/multiverse' to 'apt/ubuntu/trusty/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/restricted/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/restricted/binary-amd64/Packages.gz'. (16kB)
  + Written 49 package metadata files for component 'ubuntu/trusty/restricted' to 'apt/ubuntu/trusty/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/universe/binary-amd64/Packages.gz'. (7.59MB)
  + Written 8.566K package metadata files for component 'ubuntu/trusty/main' to 'apt/ubuntu/trusty/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-backports/main/binary-amd64/Packages.xz'...
  + Written 38 package metadata files for component 'ubuntu/xenial-backports/main' to 'apt/ubuntu/xenial-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-backports/universe/binary-amd64/Packages.xz'...
  + Written 44 package metadata files for component 'ubuntu/xenial-backports/universe' to 'apt/ubuntu/xenial-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/main/binary-amd64/Packages.xz'...
  + Written 4.4K package metadata files for component 'ubuntu/xenial-security/main' to 'apt/ubuntu/xenial-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/multiverse/binary-amd64/Packages.xz'...
  + Written 31 package metadata files for component 'ubuntu/xenial-security/multiverse' to 'apt/ubuntu/xenial-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/restricted/binary-amd64/Packages.xz'...
  + Written 38 package metadata files for component 'ubuntu/xenial-security/restricted' to 'apt/ubuntu/xenial-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/universe/binary-amd64/Packages.xz'...
  + Written 58.923K package metadata files for component 'ubuntu/jammy/universe' to 'apt/ubuntu/jammy/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/binary-amd64/Packages.xz'...
  + Written 3.395K package metadata files for component 'ubuntu/xenial-security/universe' to 'apt/ubuntu/xenial-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 80 package metadata files for component 'ubuntu/xenial-updates/multiverse' to 'apt/ubuntu/xenial-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/restricted/binary-amd64/Packages.xz'...
  + Written 39 package metadata files for component 'ubuntu/xenial-updates/restricted' to 'apt/ubuntu/xenial-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/universe/binary-amd64/Packages.xz'...
  + Written 6.065K package metadata files for component 'ubuntu/xenial-updates/main' to 'apt/ubuntu/xenial-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64/Packages.xz'...
  + Written 5.209K package metadata files for component 'ubuntu/xenial-updates/universe' to 'apt/ubuntu/xenial-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/multiverse/binary-amd64/Packages.xz'...
  + Written 782 package metadata files for component 'ubuntu/xenial/multiverse' to 'apt/ubuntu/xenial/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/restricted/binary-amd64/Packages.xz'...
  + Written 45 package metadata files for component 'ubuntu/xenial/restricted' to 'apt/ubuntu/xenial/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/Packages.xz'...
  + Written 7.322K package metadata files for component 'ubuntu/xenial/main' to 'apt/ubuntu/xenial/main'.
  + Written 35.524K package metadata files for component 'ubuntu/trusty/universe' to 'apt/ubuntu/trusty/universe'.
  + Written 64.755K package metadata files for component 'ubuntu/noble/universe' to 'apt/ubuntu/noble/universe'.
  + Written 67.461K package metadata files for component 'ubuntu/plucky/universe' to 'apt/ubuntu/plucky/universe'.
  + Written 45.688K package metadata files for component 'ubuntu/xenial/universe' to 'apt/ubuntu/xenial/universe'.
Written 760.624K package metadata files after 1m 43.3s.
Merging metadata files into observables...
  ? ubuntu/bionic/main: Generating catalog...
  ? ubuntu/bionic/multiverse: Generating catalog...
    . ubuntu/bionic/multiverse: 'ubuntu/bionic-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/bionic/main: 'ubuntu/bionic-backports/main' contributes 231 packages.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic-security/multiverse' contributes 96 packages.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic-updates/multiverse' contributes 123 packages.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic/multiverse' contributes 830 packages.
    . ubuntu/bionic/main: 'ubuntu/bionic-security/main' contributes 14.179K packages.
  ? ubuntu/bionic/multiverse: Complete. Catalog contained 33 version bundles and 887 single-version packages.
  ? ubuntu/bionic/restricted: Generating catalog...
    . ubuntu/bionic/restricted: 'ubuntu/bionic-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/bionic/restricted: 'ubuntu/bionic-security/restricted' contributes 7.339K packages.
    . ubuntu/bionic/restricted: 'ubuntu/bionic-updates/restricted' contributes 7.496K packages.
    . ubuntu/bionic/main: 'ubuntu/bionic-updates/main' contributes 15.716K packages.
    . ubuntu/bionic/restricted: 'ubuntu/bionic/restricted' contributes 50 packages.
    . ubuntu/bionic/main: 'ubuntu/bionic/main' contributes 6.391K packages.
  ? ubuntu/bionic/restricted: Complete. Catalog contained 112 version bundles and 7.401K single-version packages.
  ? ubuntu/bionic/universe: Generating catalog...
    . ubuntu/bionic/universe: 'ubuntu/bionic-backports/universe' contributes 66 packages.
    . ubuntu/bionic/universe: 'ubuntu/bionic-security/universe' contributes 6.238K packages.
    . ubuntu/bionic/universe: 'ubuntu/bionic-updates/universe' contributes 8.61K packages.
    . ubuntu/bionic/universe: 'ubuntu/bionic/universe' contributes 53.595K packages.
  ? ubuntu/bionic/main: Complete. Catalog contained 3.391K version bundles and 15.403K single-version packages.
  ? ubuntu/focal/main: Generating catalog...
    . ubuntu/focal/main: 'ubuntu/focal-backports/main' contributes 198 packages.
    . ubuntu/focal/main: 'ubuntu/focal-security/main' contributes 18.439K packages.
    . ubuntu/focal/main: 'ubuntu/focal-updates/main' contributes 20.337K packages.
    . ubuntu/focal/main: 'ubuntu/focal/main' contributes 6.09K packages.
  ? ubuntu/focal/main: Complete. Catalog contained 3.141K version bundles and 20.183K single-version packages.
  ? ubuntu/focal/multiverse: Generating catalog...
    . ubuntu/focal/multiverse: 'ubuntu/focal-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/focal/multiverse: 'ubuntu/focal-security/multiverse' contributes 116 packages.
    . ubuntu/focal/multiverse: 'ubuntu/focal-updates/multiverse' contributes 130 packages.
    . ubuntu/focal/multiverse: 'ubuntu/focal/multiverse' contributes 813 packages.
  ? ubuntu/focal/multiverse: Complete. Catalog contained 37 version bundles and 869 single-version packages.
  ? ubuntu/focal/restricted: Generating catalog...
    . ubuntu/focal/restricted: 'ubuntu/focal-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/focal/restricted: 'ubuntu/focal-security/restricted' contributes 20.884K packages.
    . ubuntu/focal/restricted: 'ubuntu/focal-updates/restricted' contributes 21.737K packages.
    . ubuntu/focal/restricted: 'ubuntu/focal/restricted' contributes 142 packages.
  ? ubuntu/bionic/universe: Complete. Catalog contained 6.657K version bundles and 48.93K single-version packages.
  ? ubuntu/focal/universe: Generating catalog...
    . ubuntu/focal/universe: 'ubuntu/focal-backports/universe' contributes 90 packages.
    . ubuntu/focal/universe: 'ubuntu/focal-security/universe' contributes 4.692K packages.
    . ubuntu/focal/universe: 'ubuntu/focal-updates/universe' contributes 5.598K packages.
    . ubuntu/focal/universe: 'ubuntu/focal/universe' contributes 53.206K packages.
  ? ubuntu/focal/restricted: Complete. Catalog contained 847 version bundles and 20.92K single-version packages.
  ? ubuntu/jammy/main: Generating catalog...
    . ubuntu/jammy/main: 'ubuntu/jammy-backports/main' contributes 194 packages.
    . ubuntu/jammy/main: 'ubuntu/jammy-security/main' contributes 13.311K packages.
    . ubuntu/jammy/main: 'ubuntu/jammy-updates/main' contributes 14.455K packages.
    . ubuntu/jammy/main: 'ubuntu/jammy/main' contributes 6.09K packages.
  ? ubuntu/jammy/main: Complete. Catalog contained 2.779K version bundles and 15.057K single-version packages.
  ? ubuntu/jammy/multiverse: Generating catalog...
    . ubuntu/jammy/multiverse: 'ubuntu/jammy-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/jammy/multiverse: 'ubuntu/jammy-security/multiverse' contributes 213 packages.
    . ubuntu/jammy/multiverse: 'ubuntu/jammy-updates/multiverse' contributes 290 packages.
    . ubuntu/jammy/multiverse: 'ubuntu/jammy/multiverse' contributes 881 packages.
  ? ubuntu/jammy/multiverse: Complete. Catalog contained 51 version bundles and 1.074K single-version packages.
  ? ubuntu/jammy/restricted: Generating catalog...
    . ubuntu/jammy/restricted: 'ubuntu/jammy-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/jammy/restricted: 'ubuntu/jammy-security/restricted' contributes 22.832K packages.
    . ubuntu/jammy/restricted: 'ubuntu/jammy-updates/restricted' contributes 23.669K packages.
    . ubuntu/jammy/restricted: 'ubuntu/jammy/restricted' contributes 681 packages.
  ? ubuntu/focal/universe: Complete. Catalog contained 4.647K version bundles and 49.549K single-version packages.
  ? ubuntu/jammy/universe: Generating catalog...
    . ubuntu/jammy/universe: 'ubuntu/jammy-backports/universe' contributes 91 packages.
    . ubuntu/jammy/universe: 'ubuntu/jammy-security/universe' contributes 4.599K packages.
    . ubuntu/jammy/universe: 'ubuntu/jammy-updates/universe' contributes 5.543K packages.
    . ubuntu/jammy/universe: 'ubuntu/jammy/universe' contributes 58.824K packages.
  ? ubuntu/jammy/restricted: Complete. Catalog contained 2.402K version bundles and 21.5K single-version packages.
  ? ubuntu/noble/main: Generating catalog...
    . ubuntu/noble/main: 'ubuntu/noble-backports/main' contributes 173 packages.
    . ubuntu/noble/main: 'ubuntu/noble-security/main' contributes 5.572K packages.
    . ubuntu/noble/main: 'ubuntu/noble-updates/main' contributes 6.781K packages.
    . ubuntu/noble/main: 'ubuntu/noble/main' contributes 6.099K packages.
  ? ubuntu/noble/main: Complete. Catalog contained 2.452K version bundles and 8.026K single-version packages.
  ? ubuntu/noble/multiverse: Generating catalog...
    . ubuntu/noble/multiverse: 'ubuntu/noble-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/noble/multiverse: 'ubuntu/noble-security/multiverse' contributes 76 packages.
    . ubuntu/noble/multiverse: 'ubuntu/noble-updates/multiverse' contributes 143 packages.
    . ubuntu/noble/multiverse: 'ubuntu/noble/multiverse' contributes 1.154K packages.
  ? ubuntu/noble/multiverse: Complete. Catalog contained 64 version bundles and 1.174K single-version packages.
  ? ubuntu/noble/restricted: Generating catalog...
    . ubuntu/noble/restricted: 'ubuntu/noble-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/noble/restricted: 'ubuntu/noble-security/restricted' contributes 9.036K packages.
    . ubuntu/noble/restricted: 'ubuntu/noble-updates/restricted' contributes 9.564K packages.
    . ubuntu/noble/restricted: 'ubuntu/noble/restricted' contributes 492 packages.
  ? ubuntu/noble/restricted: Complete. Catalog contained 1.479K version bundles and 8.203K single-version packages.
  ? ubuntu/noble/universe: Generating catalog...
    . ubuntu/noble/universe: 'ubuntu/noble-backports/universe' contributes 93 packages.
    . ubuntu/noble/universe: 'ubuntu/noble-security/universe' contributes 4.159K packages.
    . ubuntu/noble/universe: 'ubuntu/noble-updates/universe' contributes 5.148K packages.
    . ubuntu/noble/universe: 'ubuntu/noble/universe' contributes 64.754K packages.
  ? ubuntu/jammy/universe: Complete. Catalog contained 5.015K version bundles and 54.369K single-version packages.
  ? ubuntu/plucky/main: Generating catalog...
    . ubuntu/plucky/main: 'ubuntu/plucky-backports/main' contains 0 packages and is skipped.
    . ubuntu/plucky/main: 'ubuntu/plucky-security/main' contributes 797 packages.
    . ubuntu/plucky/main: 'ubuntu/plucky-updates/main' contributes 1.213K packages.
    . ubuntu/plucky/main: 'ubuntu/plucky/main' contributes 6.249K packages.
  ? ubuntu/plucky/main: Complete. Catalog contained 913 version bundles and 5.642K single-version packages.
  ? ubuntu/plucky/multiverse: Generating catalog...
    . ubuntu/plucky/multiverse: 'ubuntu/plucky-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/plucky/multiverse: 'ubuntu/plucky-security/multiverse' contributes 57 packages.
    . ubuntu/plucky/multiverse: 'ubuntu/plucky-updates/multiverse' contributes 108 packages.
    . ubuntu/plucky/multiverse: 'ubuntu/plucky/multiverse' contributes 1.095K packages.
  ? ubuntu/plucky/multiverse: Complete. Catalog contained 57 version bundles and 1.089K single-version packages.
  ? ubuntu/plucky/restricted: Generating catalog...
    . ubuntu/plucky/restricted: 'ubuntu/plucky-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/plucky/restricted: 'ubuntu/plucky-security/restricted' contributes 798 packages.
    . ubuntu/plucky/restricted: 'ubuntu/plucky-updates/restricted' contributes 891 packages.
    . ubuntu/plucky/restricted: 'ubuntu/plucky/restricted' contributes 264 packages.
  ? ubuntu/plucky/restricted: Complete. Catalog contained 340 version bundles and 558 single-version packages.
  ? ubuntu/plucky/universe: Generating catalog...
    . ubuntu/plucky/universe: 'ubuntu/plucky-backports/universe' contains 0 packages and is skipped.
    . ubuntu/plucky/universe: 'ubuntu/plucky-security/universe' contributes 459 packages.
    . ubuntu/plucky/universe: 'ubuntu/plucky-updates/universe' contributes 819 packages.
    . ubuntu/plucky/universe: 'ubuntu/plucky/universe' contributes 67.234K packages.
  ? ubuntu/noble/universe: Complete. Catalog contained 4.336K version bundles and 61.277K single-version packages.
  ? ubuntu/trusty/main: Generating catalog...
    . ubuntu/trusty/main: 'ubuntu/trusty-backports/main' contributes 63 packages.
    . ubuntu/trusty/main: 'ubuntu/trusty-security/main' contributes 2.805K packages.
    . ubuntu/trusty/main: 'ubuntu/trusty-updates/main' contributes 4.993K packages.
    . ubuntu/trusty/main: 'ubuntu/trusty/main' contributes 8.566K packages.
  ? ubuntu/trusty/main: Complete. Catalog contained 4.291K version bundles and 5.016K single-version packages.
  ? ubuntu/trusty/multiverse: Generating catalog...
    . ubuntu/trusty/multiverse: 'ubuntu/trusty-backports/multiverse' contributes 4 packages.
    . ubuntu/trusty/multiverse: 'ubuntu/trusty-security/multiverse' contributes 17 packages.
    . ubuntu/trusty/multiverse: 'ubuntu/trusty-updates/multiverse' contributes 65 packages.
    . ubuntu/trusty/multiverse: 'ubuntu/trusty/multiverse' contributes 741 packages.
  ? ubuntu/trusty/multiverse: Complete. Catalog contained 55 version bundles and 704 single-version packages.
  ? ubuntu/trusty/restricted: Generating catalog...
    . ubuntu/trusty/restricted: 'ubuntu/trusty-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/trusty/restricted: 'ubuntu/trusty-security/restricted' contributes 77 packages.
    . ubuntu/trusty/restricted: 'ubuntu/trusty-updates/restricted' contributes 86 packages.
    . ubuntu/trusty/restricted: 'ubuntu/trusty/restricted' contributes 49 packages.
  ? ubuntu/trusty/restricted: Complete. Catalog contained 56 version bundles and 40 single-version packages.
  ? ubuntu/trusty/universe: Generating catalog...
    . ubuntu/trusty/universe: 'ubuntu/trusty-backports/universe' contributes 244 packages.
    . ubuntu/trusty/universe: 'ubuntu/trusty-security/universe' contributes 1.6K packages.
    . ubuntu/trusty/universe: 'ubuntu/trusty-updates/universe' contributes 2.878K packages.
    . ubuntu/trusty/universe: 'ubuntu/trusty/universe' contributes 35.524K packages.
  ? ubuntu/plucky/universe: Complete. Catalog contained 746 version bundles and 66.561K single-version packages.
  ? ubuntu/xenial/main: Generating catalog...
    . ubuntu/xenial/main: 'ubuntu/xenial-backports/main' contributes 33 packages.
    . ubuntu/xenial/main: 'ubuntu/xenial-security/main' contributes 3.92K packages.
    . ubuntu/xenial/main: 'ubuntu/xenial-updates/main' contributes 5.548K packages.
    . ubuntu/xenial/main: 'ubuntu/xenial/main' contributes 7.322K packages.
  ? ubuntu/xenial/main: Complete. Catalog contained 3.634K version bundles and 5.618K single-version packages.
  ? ubuntu/xenial/multiverse: Generating catalog...
    . ubuntu/xenial/multiverse: 'ubuntu/xenial-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/xenial/multiverse: 'ubuntu/xenial-security/multiverse' contributes 31 packages.
    . ubuntu/xenial/multiverse: 'ubuntu/xenial-updates/multiverse' contributes 80 packages.
    . ubuntu/xenial/multiverse: 'ubuntu/xenial/multiverse' contributes 782 packages.
  ? ubuntu/xenial/multiverse: Complete. Catalog contained 75 version bundles and 716 single-version packages.
  ? ubuntu/xenial/restricted: Generating catalog...
    . ubuntu/xenial/restricted: 'ubuntu/xenial-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/xenial/restricted: 'ubuntu/xenial-security/restricted' contributes 38 packages.
    . ubuntu/xenial/restricted: 'ubuntu/xenial-updates/restricted' contributes 39 packages.
    . ubuntu/xenial/restricted: 'ubuntu/xenial/restricted' contributes 45 packages.
  ? ubuntu/xenial/restricted: Complete. Catalog contained 34 version bundles and 22 single-version packages.
  ? ubuntu/xenial/universe: Generating catalog...
    . ubuntu/xenial/universe: 'ubuntu/xenial-backports/universe' contributes 42 packages.
    . ubuntu/xenial/universe: 'ubuntu/xenial-security/universe' contributes 3.286K packages.
    . ubuntu/xenial/universe: 'ubuntu/xenial-updates/universe' contributes 5.094K packages.
    . ubuntu/xenial/universe: 'ubuntu/xenial/universe' contributes 45.688K packages.
  ? ubuntu/trusty/universe: Complete. Catalog contained 2.713K version bundles and 33.113K single-version packages.
  ? ubuntu/xenial/universe: Complete. Catalog contained 4.304K version bundles and 42.213K single-version packages.
Observables successfully generated after 2m 50.6s.
Completed successfully after 4m 33.9s.
```
