### PR TITLE
chore: Update Metadata from Snapshot 2026-05-10T03:56:46+00:00

### DIFF
--- a/apt/ubuntu/noble-backports/universe/python3-virt-firmware.json
+++ b/apt/ubuntu/noble-backports/universe/python3-virt-firmware.json
@@ -1,4 +1,4 @@
-[{
+{
 	"raw": {},
 	"required": [
 		"Filename",
@@ -30,33 +30,4 @@
 	"sha256": "50eb8126ff7509ed12235eb02efe696067d62524e1dc7d5a4b63d6c0b15a2552",
 	"sha512": "d9a7a0e517dd2deeaba8c298dc118bfab1a3fb465b297c7e35f8a287d4429cc35597d27856ea012a70056042b893d34556e69b57584998a0bf16403e38ad46d6",
 	"descriptionMd5": "7f70563095a4a6ff907eddc8996d14e5"
-},{
-	"raw": {},
-	"required": [
-		"Filename",
-		"Size"
-	],
-	"package": "python3-virt-firmware",
-	"source": "virt-firmware",
-	"version": "24.1.1-2",
-	"section": "universe/python",
-	"priority": "optional",
-	"architecture": "all",
-	"depends": [
-		"python3-cryptography",
-		"python3-pefile",
-		"python3-pkg-resources",
-		"python3:any"
-	],
-	"installedSize": 287,
-	"maintainer": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
-	"description": "Tools for manipulating edk2 (ovmf/qemu-efi) firmware images",
-	"homepage": "https://gitlab.com/kraxel/virt-firmware",
-	"filename": "pool/universe/v/virt-firmware/python3-virt-firmware_24.1.1-2_all.deb",
-	"size": 71972,
-	"md5": "cb6a97e1abd2541174230b95406a02a1",
-	"sha1": "5bc61ef0b6b39fa7b9d49b799b05938d0224348a",
-	"sha256": "27f1b7e0f7370fb05b97e0e61681c3a8df0f6811c160637c4c5306a5027bae62",
-	"sha512": "909bc8a93ca3e4bc2b3f87f4d65a70ea318f90d4d7981dd92f2ad0717ac72bf0d7bd87f705c9676c9c00043162b32d365f18cd00b2575acfde8658e44f3e698a",
-	"descriptionMd5": "3c6b3df132780ca9ee7242dd4375e44b"
-}]
+}


### PR DESCRIPTION
## Metadata Log
```shell
Generating tasks...
Generating metadata in /home/runner/work/generator/generator/apt...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-backports/main/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-backports/universe/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/main/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/multiverse/binary-amd64/Packages.xz'...
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/restricted/binary-amd64/Packages.xz'...
  + Written 66 package metadata files for component 'ubuntu/bionic-backports/universe' to 'apt/ubuntu/bionic-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-security/universe/binary-amd64/Packages.xz'...
  + Written 96 package metadata files for component 'ubuntu/bionic-security/multiverse' to 'apt/ubuntu/bionic-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/binary-amd64/Packages.xz'...
  + Written 231 package metadata files for component 'ubuntu/bionic-backports/main' to 'apt/ubuntu/bionic-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 123 package metadata files for component 'ubuntu/bionic-updates/multiverse' to 'apt/ubuntu/bionic-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/restricted/binary-amd64/Packages.xz'...
  + Written 6.423K package metadata files for component 'ubuntu/bionic-security/universe' to 'apt/ubuntu/bionic-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/binary-amd64/Packages.xz'...
  + Written 7.342K package metadata files for component 'ubuntu/bionic-security/restricted' to 'apt/ubuntu/bionic-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/main/binary-amd64/Packages.xz'...
  + Written 7.5K package metadata files for component 'ubuntu/bionic-updates/restricted' to 'apt/ubuntu/bionic-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/multiverse/binary-amd64/Packages.xz'...
  + Written 830 package metadata files for component 'ubuntu/bionic/multiverse' to 'apt/ubuntu/bionic/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/restricted/binary-amd64/Packages.xz'...
  + Written 50 package metadata files for component 'ubuntu/bionic/restricted' to 'apt/ubuntu/bionic/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/Packages.xz'...
  + Written 6.391K package metadata files for component 'ubuntu/bionic/main' to 'apt/ubuntu/bionic/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-backports/main/binary-amd64/Packages.xz'...
  + Written 198 package metadata files for component 'ubuntu/focal-backports/main' to 'apt/ubuntu/focal-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-backports/universe/binary-amd64/Packages.xz'...
  + Written 14.99K package metadata files for component 'ubuntu/bionic-security/main' to 'apt/ubuntu/bionic-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/main/binary-amd64/Packages.xz'...
  + Written 90 package metadata files for component 'ubuntu/focal-backports/universe' to 'apt/ubuntu/focal-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/multiverse/binary-amd64/Packages.xz'...
  + Written 116 package metadata files for component 'ubuntu/focal-security/multiverse' to 'apt/ubuntu/focal-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/restricted/binary-amd64/Packages.xz'...
  + Written 9.35K package metadata files for component 'ubuntu/bionic-updates/universe' to 'apt/ubuntu/bionic-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-security/universe/binary-amd64/Packages.xz'...
  + Written 16.566K package metadata files for component 'ubuntu/bionic-updates/main' to 'apt/ubuntu/bionic-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/main/binary-amd64/Packages.xz'...
  + Written 5.056K package metadata files for component 'ubuntu/focal-security/universe' to 'apt/ubuntu/focal-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 130 package metadata files for component 'ubuntu/focal-updates/multiverse' to 'apt/ubuntu/focal-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/restricted/binary-amd64/Packages.xz'...
  + Written 20.027K package metadata files for component 'ubuntu/focal-security/main' to 'apt/ubuntu/focal-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal-updates/universe/binary-amd64/Packages.xz'...
  + Written 20.926K package metadata files for component 'ubuntu/focal-security/restricted' to 'apt/ubuntu/focal-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64/Packages.xz'...
  + Written 21.987K package metadata files for component 'ubuntu/focal-updates/main' to 'apt/ubuntu/focal-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/multiverse/binary-amd64/Packages.xz'...
  + Written 813 package metadata files for component 'ubuntu/focal/multiverse' to 'apt/ubuntu/focal/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/restricted/binary-amd64/Packages.xz'...
  + Written 143 package metadata files for component 'ubuntu/focal/restricted' to 'apt/ubuntu/focal/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.xz'...
  + Written 5.969K package metadata files for component 'ubuntu/focal-updates/universe' to 'apt/ubuntu/focal-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-backports/main/binary-amd64/Packages.xz'...
  + Written 338 package metadata files for component 'ubuntu/jammy-backports/main' to 'apt/ubuntu/jammy-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-backports/universe/binary-amd64/Packages.xz'...
  + Written 6.09K package metadata files for component 'ubuntu/focal/main' to 'apt/ubuntu/focal/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/main/binary-amd64/Packages.xz'...
  + Written 21.779K package metadata files for component 'ubuntu/focal-updates/restricted' to 'apt/ubuntu/focal-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/multiverse/binary-amd64/Packages.xz'...
  + Written 123 package metadata files for component 'ubuntu/jammy-backports/universe' to 'apt/ubuntu/jammy-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/restricted/binary-amd64/Packages.xz'...
  + Written 277 package metadata files for component 'ubuntu/jammy-security/multiverse' to 'apt/ubuntu/jammy-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-security/universe/binary-amd64/Packages.xz'...
  + Written 4.917K package metadata files for component 'ubuntu/jammy-security/universe' to 'apt/ubuntu/jammy-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/Packages.xz'...
  + Written 17.982K package metadata files for component 'ubuntu/jammy-security/main' to 'apt/ubuntu/jammy-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 356 package metadata files for component 'ubuntu/jammy-updates/multiverse' to 'apt/ubuntu/jammy-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/restricted/binary-amd64/Packages.xz'...
  + Written 53.596K package metadata files for component 'ubuntu/bionic/universe' to 'apt/ubuntu/bionic/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy-updates/universe/binary-amd64/Packages.xz'...
  + Written 19.231K package metadata files for component 'ubuntu/jammy-updates/main' to 'apt/ubuntu/jammy-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64/Packages.xz'...
  + Written 5.874K package metadata files for component 'ubuntu/jammy-updates/universe' to 'apt/ubuntu/jammy-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/multiverse/binary-amd64/Packages.xz'...
  + Written 881 package metadata files for component 'ubuntu/jammy/multiverse' to 'apt/ubuntu/jammy/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/restricted/binary-amd64/Packages.xz'...
  + Written 686 package metadata files for component 'ubuntu/jammy/restricted' to 'apt/ubuntu/jammy/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/jammy/universe/binary-amd64/Packages.xz'...
  + Written 31.478K package metadata files for component 'ubuntu/jammy-security/restricted' to 'apt/ubuntu/jammy-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-backports/main/binary-amd64/Packages.xz'...
  + Written 6.09K package metadata files for component 'ubuntu/jammy/main' to 'apt/ubuntu/jammy/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-backports/universe/binary-amd64/Packages.xz'...
  + Written 175 package metadata files for component 'ubuntu/noble-backports/main' to 'apt/ubuntu/noble-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/Packages.xz'...
  + Written 115 package metadata files for component 'ubuntu/noble-backports/universe' to 'apt/ubuntu/noble-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/multiverse/binary-amd64/Packages.xz'...
  + Written 141 package metadata files for component 'ubuntu/noble-security/multiverse' to 'apt/ubuntu/noble-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/restricted/binary-amd64/Packages.xz'...
  + Written 9.035K package metadata files for component 'ubuntu/noble-security/main' to 'apt/ubuntu/noble-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/Packages.xz'...
  + Written 5.773K package metadata files for component 'ubuntu/noble-security/universe' to 'apt/ubuntu/noble-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/Packages.xz'...
  + Written 16.287K package metadata files for component 'ubuntu/noble-security/restricted' to 'apt/ubuntu/noble-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 215 package metadata files for component 'ubuntu/noble-updates/multiverse' to 'apt/ubuntu/noble-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/restricted/binary-amd64/Packages.xz'...
  + Written 53.206K package metadata files for component 'ubuntu/focal/universe' to 'apt/ubuntu/focal/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/Packages.xz'...
  + Written 32.575K package metadata files for component 'ubuntu/jammy-updates/restricted' to 'apt/ubuntu/jammy-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/Packages.xz'...
  + Written 6.099K package metadata files for component 'ubuntu/noble/main' to 'apt/ubuntu/noble/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/multiverse/binary-amd64/Packages.xz'...
  + Written 10.399K package metadata files for component 'ubuntu/noble-updates/main' to 'apt/ubuntu/noble-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/restricted/binary-amd64/Packages.xz'...
  + Written 492 package metadata files for component 'ubuntu/noble/restricted' to 'apt/ubuntu/noble/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/Packages.xz'...
  + Written 1.154K package metadata files for component 'ubuntu/noble/multiverse' to 'apt/ubuntu/noble/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-security/main/binary-amd64/Packages.xz'...
  + Written 8.178K package metadata files for component 'ubuntu/noble-updates/universe' to 'apt/ubuntu/noble-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-security/multiverse/binary-amd64/Packages.xz'...
  + Written 10 package metadata files for component 'ubuntu/questing-security/multiverse' to 'apt/ubuntu/questing-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-security/restricted/binary-amd64/Packages.xz'...
  + Written 1.429K package metadata files for component 'ubuntu/questing-security/main' to 'apt/ubuntu/questing-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-security/universe/binary-amd64/Packages.xz'...
  + Written 1.279K package metadata files for component 'ubuntu/questing-security/restricted' to 'apt/ubuntu/questing-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-updates/main/binary-amd64/Packages.xz'...
  + Written 1.053K package metadata files for component 'ubuntu/questing-security/universe' to 'apt/ubuntu/questing-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 70 package metadata files for component 'ubuntu/questing-updates/multiverse' to 'apt/ubuntu/questing-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-updates/restricted/binary-amd64/Packages.xz'...
  + Written 1.892K package metadata files for component 'ubuntu/questing-updates/main' to 'apt/ubuntu/questing-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing-updates/universe/binary-amd64/Packages.xz'...
  + Written 1.365K package metadata files for component 'ubuntu/questing-updates/restricted' to 'apt/ubuntu/questing-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing/main/binary-amd64/Packages.xz'...
  + Written 1.329K package metadata files for component 'ubuntu/questing-updates/universe' to 'apt/ubuntu/questing-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing/multiverse/binary-amd64/Packages.xz'...
  + Written 1.177K package metadata files for component 'ubuntu/questing/multiverse' to 'apt/ubuntu/questing/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing/restricted/binary-amd64/Packages.xz'...
  + Written 17.265K package metadata files for component 'ubuntu/noble-updates/restricted' to 'apt/ubuntu/noble-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/questing/universe/binary-amd64/Packages.xz'...
  + Written 401 package metadata files for component 'ubuntu/questing/restricted' to 'apt/ubuntu/questing/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-backports/main/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-backports/main' to 'apt/ubuntu/resolute-backports/main'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-backports": ["main"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-backports/multiverse/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-backports/multiverse' to 'apt/ubuntu/resolute-backports/multiverse'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-backports": ["multiverse"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-backports/restricted/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-backports/restricted' to 'apt/ubuntu/resolute-backports/restricted'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-backports": ["restricted"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-backports/universe/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-backports/universe' to 'apt/ubuntu/resolute-backports/universe'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-backports": ["universe"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-security/main/binary-amd64/Packages.xz'...
  + Written 111 package metadata files for component 'ubuntu/resolute-security/main' to 'apt/ubuntu/resolute-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-security/multiverse/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-security/multiverse' to 'apt/ubuntu/resolute-security/multiverse'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-security": ["multiverse"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-security/restricted/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-security/restricted' to 'apt/ubuntu/resolute-security/restricted'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-security": ["restricted"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-security/universe/binary-amd64/Packages.xz'...
  + Written 79 package metadata files for component 'ubuntu/resolute-security/universe' to 'apt/ubuntu/resolute-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-updates/main/binary-amd64/Packages.xz'...
  + Written 314 package metadata files for component 'ubuntu/resolute-updates/main' to 'apt/ubuntu/resolute-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 0 package metadata files for component 'ubuntu/resolute-updates/multiverse' to 'apt/ubuntu/resolute-updates/multiverse'.
	!
	! If it is reasonable to expect that this component will never have any entries, mark the component as empty in your configuration:
	!   emptyComponents: { "resolute-updates": ["multiverse"] }
	!
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-updates/restricted/binary-amd64/Packages.xz'...
  + Written 169 package metadata files for component 'ubuntu/resolute-updates/restricted' to 'apt/ubuntu/resolute-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute-updates/universe/binary-amd64/Packages.xz'...
  + Written 6.298K package metadata files for component 'ubuntu/questing/main' to 'apt/ubuntu/questing/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute/main/binary-amd64/Packages.xz'...
  + Written 79 package metadata files for component 'ubuntu/resolute-updates/universe' to 'apt/ubuntu/resolute-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute/multiverse/binary-amd64/Packages.xz'...
  + Written 1.242K package metadata files for component 'ubuntu/resolute/multiverse' to 'apt/ubuntu/resolute/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute/restricted/binary-amd64/Packages.xz'...
  + Written 858 package metadata files for component 'ubuntu/resolute/restricted' to 'apt/ubuntu/resolute/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.xz'...
  + Written 6.487K package metadata files for component 'ubuntu/resolute/main' to 'apt/ubuntu/resolute/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/main/binary-amd64/Packages.gz'. (20kB)
  + Written 63 package metadata files for component 'ubuntu/trusty-backports/main' to 'apt/ubuntu/trusty-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/multiverse/binary-amd64/Packages.gz'. (1.74kB)
  + Written 4 package metadata files for component 'ubuntu/trusty-backports/multiverse' to 'apt/ubuntu/trusty-backports/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-backports/universe/binary-amd64/Packages.gz'. (72.8kB)
  + Written 244 package metadata files for component 'ubuntu/trusty-backports/universe' to 'apt/ubuntu/trusty-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/main/binary-amd64/Packages.gz'. (878kB)
  + Written 3.221K package metadata files for component 'ubuntu/trusty-security/main' to 'apt/ubuntu/trusty-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/multiverse/binary-amd64/Packages.gz'. (6.13kB)
  + Written 17 package metadata files for component 'ubuntu/trusty-security/multiverse' to 'apt/ubuntu/trusty-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/restricted/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/restricted/binary-amd64/Packages.gz'. (24.6kB)
  + Written 77 package metadata files for component 'ubuntu/trusty-security/restricted' to 'apt/ubuntu/trusty-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-security/universe/binary-amd64/Packages.gz'. (489kB)
  + Written 1.632K package metadata files for component 'ubuntu/trusty-security/universe' to 'apt/ubuntu/trusty-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/binary-amd64/Packages.gz'. (1.46MB)
  + Written 58.923K package metadata files for component 'ubuntu/jammy/universe' to 'apt/ubuntu/jammy/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/multiverse/binary-amd64/Packages.gz'. (21.7kB)
  + Written 65 package metadata files for component 'ubuntu/trusty-updates/multiverse' to 'apt/ubuntu/trusty-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/restricted/binary-amd64/Packages.gz'...
  + Written 5.435K package metadata files for component 'ubuntu/trusty-updates/main' to 'apt/ubuntu/trusty-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/restricted/binary-amd64/Packages.gz'. (28.8kB)
  + Written 86 package metadata files for component 'ubuntu/trusty-updates/restricted' to 'apt/ubuntu/trusty-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/Packages.gz'. (1.74MB)
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/universe/binary-amd64/Packages.gz'. (883kB)
  + Written 2.91K package metadata files for component 'ubuntu/trusty-updates/universe' to 'apt/ubuntu/trusty-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/multiverse/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/multiverse/binary-amd64/Packages.gz'. (169kB)
  + Written 741 package metadata files for component 'ubuntu/trusty/multiverse' to 'apt/ubuntu/trusty/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/restricted/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/restricted/binary-amd64/Packages.gz'. (16kB)
  + Written 49 package metadata files for component 'ubuntu/trusty/restricted' to 'apt/ubuntu/trusty/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/trusty/universe/binary-amd64/Packages.gz'...
  . Received HTTP 200 response for 'http://archive.ubuntu.com/ubuntu/dists/trusty/universe/binary-amd64/Packages.gz'. (7.59MB)
  + Written 8.566K package metadata files for component 'ubuntu/trusty/main' to 'apt/ubuntu/trusty/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-backports/main/binary-amd64/Packages.xz'...
  + Written 38 package metadata files for component 'ubuntu/xenial-backports/main' to 'apt/ubuntu/xenial-backports/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-backports/universe/binary-amd64/Packages.xz'...
  + Written 44 package metadata files for component 'ubuntu/xenial-backports/universe' to 'apt/ubuntu/xenial-backports/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/main/binary-amd64/Packages.xz'...
  + Written 4.4K package metadata files for component 'ubuntu/xenial-security/main' to 'apt/ubuntu/xenial-security/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/multiverse/binary-amd64/Packages.xz'...
  + Written 31 package metadata files for component 'ubuntu/xenial-security/multiverse' to 'apt/ubuntu/xenial-security/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/restricted/binary-amd64/Packages.xz'...
  + Written 38 package metadata files for component 'ubuntu/xenial-security/restricted' to 'apt/ubuntu/xenial-security/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-security/universe/binary-amd64/Packages.xz'...
  + Written 3.395K package metadata files for component 'ubuntu/xenial-security/universe' to 'apt/ubuntu/xenial-security/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/binary-amd64/Packages.xz'...
  + Written 6.065K package metadata files for component 'ubuntu/xenial-updates/main' to 'apt/ubuntu/xenial-updates/main'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/multiverse/binary-amd64/Packages.xz'...
  + Written 80 package metadata files for component 'ubuntu/xenial-updates/multiverse' to 'apt/ubuntu/xenial-updates/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/restricted/binary-amd64/Packages.xz'...
  + Written 39 package metadata files for component 'ubuntu/xenial-updates/restricted' to 'apt/ubuntu/xenial-updates/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial-updates/universe/binary-amd64/Packages.xz'...
  + Written 5.209K package metadata files for component 'ubuntu/xenial-updates/universe' to 'apt/ubuntu/xenial-updates/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64/Packages.xz'...
  + Written 64.755K package metadata files for component 'ubuntu/noble/universe' to 'apt/ubuntu/noble/universe'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/multiverse/binary-amd64/Packages.xz'...
  + Written 782 package metadata files for component 'ubuntu/xenial/multiverse' to 'apt/ubuntu/xenial/multiverse'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/restricted/binary-amd64/Packages.xz'...
  + Written 45 package metadata files for component 'ubuntu/xenial/restricted' to 'apt/ubuntu/xenial/restricted'.
  . Processing 'http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/Packages.xz'...
  + Written 35.524K package metadata files for component 'ubuntu/trusty/universe' to 'apt/ubuntu/trusty/universe'.
  + Written 7.322K package metadata files for component 'ubuntu/xenial/main' to 'apt/ubuntu/xenial/main'.
  + Written 65.486K package metadata files for component 'ubuntu/questing/universe' to 'apt/ubuntu/questing/universe'.
  + Written 66.741K package metadata files for component 'ubuntu/resolute/universe' to 'apt/ubuntu/resolute/universe'.
  + Written 45.688K package metadata files for component 'ubuntu/xenial/universe' to 'apt/ubuntu/xenial/universe'.
Written 889.577K package metadata files after 2m 11s.
Merging metadata files into observables...
  ? ubuntu/bionic/main: Generating catalog...
  ? ubuntu/bionic/multiverse: Generating catalog...
    . ubuntu/bionic/main: 'ubuntu/bionic-backports/main' contributes 231 packages.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic-security/multiverse' contributes 96 packages.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic-updates/multiverse' contributes 123 packages.
    . ubuntu/bionic/multiverse: 'ubuntu/bionic/multiverse' contributes 830 packages.
    . ubuntu/bionic/main: 'ubuntu/bionic-security/main' contributes 14.179K packages.
  ? ubuntu/bionic/multiverse: Complete. Catalog contained 33 version bundles and 887 single-version packages.
  ? ubuntu/bionic/restricted: Generating catalog...
    . ubuntu/bionic/restricted: 'ubuntu/bionic-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/bionic/restricted: 'ubuntu/bionic-security/restricted' contributes 7.339K packages.
    . ubuntu/bionic/restricted: 'ubuntu/bionic-updates/restricted' contributes 7.496K packages.
    . ubuntu/bionic/main: 'ubuntu/bionic-updates/main' contributes 15.716K packages.
    . ubuntu/bionic/restricted: 'ubuntu/bionic/restricted' contributes 50 packages.
    . ubuntu/bionic/main: 'ubuntu/bionic/main' contributes 6.391K packages.
  ? ubuntu/bionic/restricted: Complete. Catalog contained 112 version bundles and 7.401K single-version packages.
  ? ubuntu/bionic/universe: Generating catalog...
    . ubuntu/bionic/universe: 'ubuntu/bionic-backports/universe' contributes 66 packages.
    . ubuntu/bionic/universe: 'ubuntu/bionic-security/universe' contributes 6.238K packages.
    . ubuntu/bionic/universe: 'ubuntu/bionic-updates/universe' contributes 8.61K packages.
    . ubuntu/bionic/universe: 'ubuntu/bionic/universe' contributes 53.595K packages.
  ? ubuntu/bionic/main: Complete. Catalog contained 3.391K version bundles and 15.403K single-version packages.
  ? ubuntu/focal/main: Generating catalog...
    . ubuntu/focal/main: 'ubuntu/focal-backports/main' contributes 198 packages.
    . ubuntu/focal/main: 'ubuntu/focal-security/main' contributes 18.439K packages.
    . ubuntu/focal/main: 'ubuntu/focal-updates/main' contributes 20.34K packages.
    . ubuntu/focal/main: 'ubuntu/focal/main' contributes 6.09K packages.
  ? ubuntu/focal/main: Complete. Catalog contained 3.148K version bundles and 20.179K single-version packages.
  ? ubuntu/focal/multiverse: Generating catalog...
    . ubuntu/focal/multiverse: 'ubuntu/focal-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/focal/multiverse: 'ubuntu/focal-security/multiverse' contributes 116 packages.
    . ubuntu/focal/multiverse: 'ubuntu/focal-updates/multiverse' contributes 130 packages.
    . ubuntu/focal/multiverse: 'ubuntu/focal/multiverse' contributes 813 packages.
  ? ubuntu/focal/multiverse: Complete. Catalog contained 37 version bundles and 869 single-version packages.
  ? ubuntu/focal/restricted: Generating catalog...
    . ubuntu/focal/restricted: 'ubuntu/focal-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/focal/restricted: 'ubuntu/focal-security/restricted' contributes 20.884K packages.
    . ubuntu/focal/restricted: 'ubuntu/focal-updates/restricted' contributes 21.737K packages.
  ? ubuntu/bionic/universe: Complete. Catalog contained 6.657K version bundles and 48.93K single-version packages.
  ? ubuntu/focal/universe: Generating catalog...
    . ubuntu/focal/universe: 'ubuntu/focal-backports/universe' contributes 90 packages.
    . ubuntu/focal/universe: 'ubuntu/focal-security/universe' contributes 4.692K packages.
    . ubuntu/focal/restricted: 'ubuntu/focal/restricted' contributes 142 packages.
    . ubuntu/focal/universe: 'ubuntu/focal-updates/universe' contributes 5.597K packages.
    . ubuntu/focal/universe: 'ubuntu/focal/universe' contributes 53.206K packages.
  ? ubuntu/focal/restricted: Complete. Catalog contained 847 version bundles and 20.92K single-version packages.
  ? ubuntu/jammy/main: Generating catalog...
    . ubuntu/jammy/main: 'ubuntu/jammy-backports/main' contributes 196 packages.
    . ubuntu/jammy/main: 'ubuntu/jammy-security/main' contributes 16.403K packages.
    . ubuntu/jammy/main: 'ubuntu/jammy-updates/main' contributes 17.627K packages.
    . ubuntu/jammy/main: 'ubuntu/jammy/main' contributes 6.09K packages.
  ? ubuntu/jammy/main: Complete. Catalog contained 2.861K version bundles and 18.067K single-version packages.
  ? ubuntu/jammy/multiverse: Generating catalog...
    . ubuntu/jammy/multiverse: 'ubuntu/jammy-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/jammy/multiverse: 'ubuntu/jammy-security/multiverse' contributes 276 packages.
    . ubuntu/jammy/multiverse: 'ubuntu/jammy-updates/multiverse' contributes 353 packages.
    . ubuntu/jammy/multiverse: 'ubuntu/jammy/multiverse' contributes 881 packages.
  ? ubuntu/jammy/multiverse: Complete. Catalog contained 63 version bundles and 1.125K single-version packages.
  ? ubuntu/jammy/restricted: Generating catalog...
    . ubuntu/jammy/restricted: 'ubuntu/jammy-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/jammy/restricted: 'ubuntu/jammy-security/restricted' contributes 31.417K packages.
    . ubuntu/jammy/restricted: 'ubuntu/jammy-updates/restricted' contributes 32.504K packages.
  ? ubuntu/focal/universe: Complete. Catalog contained 4.647K version bundles and 49.548K single-version packages.
  ? ubuntu/jammy/universe: Generating catalog...
    . ubuntu/jammy/universe: 'ubuntu/jammy-backports/universe' contributes 93 packages.
    . ubuntu/jammy/universe: 'ubuntu/jammy-security/universe' contributes 4.767K packages.
    . ubuntu/jammy/universe: 'ubuntu/jammy-updates/universe' contributes 5.724K packages.
    . ubuntu/jammy/universe: 'ubuntu/jammy/universe' contributes 58.824K packages.
    . ubuntu/jammy/restricted: 'ubuntu/jammy/restricted' contributes 681 packages.
  ? ubuntu/jammy/restricted: Complete. Catalog contained 3.071K version bundles and 29.666K single-version packages.
  ? ubuntu/noble/main: Generating catalog...
    . ubuntu/noble/main: 'ubuntu/noble-backports/main' contributes 175 packages.
    . ubuntu/noble/main: 'ubuntu/noble-security/main' contributes 8.755K packages.
    . ubuntu/noble/main: 'ubuntu/noble-updates/main' contributes 10.114K packages.
    . ubuntu/noble/main: 'ubuntu/noble/main' contributes 6.099K packages.
  ? ubuntu/noble/main: Complete. Catalog contained 2.645K version bundles and 10.983K single-version packages.
  ? ubuntu/noble/multiverse: Generating catalog...
    . ubuntu/noble/multiverse: 'ubuntu/noble-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/noble/multiverse: 'ubuntu/noble-security/multiverse' contributes 137 packages.
    . ubuntu/noble/multiverse: 'ubuntu/noble-updates/multiverse' contributes 208 packages.
    . ubuntu/noble/multiverse: 'ubuntu/noble/multiverse' contributes 1.154K packages.
  ? ubuntu/noble/multiverse: Complete. Catalog contained 78 version bundles and 1.221K single-version packages.
  ? ubuntu/noble/restricted: Generating catalog...
    . ubuntu/noble/restricted: 'ubuntu/noble-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/noble/restricted: 'ubuntu/noble-security/restricted' contributes 16.258K packages.
    . ubuntu/noble/restricted: 'ubuntu/noble-updates/restricted' contributes 17.228K packages.
    . ubuntu/noble/restricted: 'ubuntu/noble/restricted' contributes 492 packages.
  ? ubuntu/jammy/universe: Complete. Catalog contained 5.086K version bundles and 54.408K single-version packages.
  ? ubuntu/noble/universe: Generating catalog...
    . ubuntu/noble/universe: 'ubuntu/noble-backports/universe' contributes 101 packages.
    . ubuntu/noble/universe: 'ubuntu/noble-security/universe' contributes 5.722K packages.
    . ubuntu/noble/universe: 'ubuntu/noble-updates/universe' contributes 8.118K packages.
    . ubuntu/noble/universe: 'ubuntu/noble/universe' contributes 64.754K packages.
  ? ubuntu/noble/restricted: Complete. Catalog contained 2.002K version bundles and 15.344K single-version packages.
  ? ubuntu/questing/main: Generating catalog...
    . ubuntu/questing/main: 'ubuntu/questing-backports/main' contains 0 packages and is skipped.
    . ubuntu/questing/main: 'ubuntu/questing-security/main' contributes 1.389K packages.
    . ubuntu/questing/main: 'ubuntu/questing-updates/main' contributes 1.852K packages.
    . ubuntu/questing/main: 'ubuntu/questing/main' contributes 6.296K packages.
  ? ubuntu/questing/main: Complete. Catalog contained 1.342K version bundles and 5.476K single-version packages.
  ? ubuntu/questing/multiverse: Generating catalog...
    . ubuntu/questing/multiverse: 'ubuntu/questing-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/questing/multiverse: 'ubuntu/questing-security/multiverse' contributes 10 packages.
    . ubuntu/questing/multiverse: 'ubuntu/questing-updates/multiverse' contributes 70 packages.
    . ubuntu/questing/multiverse: 'ubuntu/questing/multiverse' contributes 1.177K packages.
  ? ubuntu/questing/multiverse: Complete. Catalog contained 19 version bundles and 1.214K single-version packages.
  ? ubuntu/questing/restricted: Generating catalog...
    . ubuntu/questing/restricted: 'ubuntu/questing-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/questing/restricted: 'ubuntu/questing-security/restricted' contributes 1.277K packages.
    . ubuntu/questing/restricted: 'ubuntu/questing-updates/restricted' contributes 1.361K packages.
    . ubuntu/questing/restricted: 'ubuntu/questing/restricted' contributes 401 packages.
  ? ubuntu/questing/restricted: Complete. Catalog contained 505 version bundles and 906 single-version packages.
  ? ubuntu/questing/universe: Generating catalog...
    . ubuntu/questing/universe: 'ubuntu/questing-backports/universe' contains 0 packages and is skipped.
    . ubuntu/questing/universe: 'ubuntu/questing-security/universe' contributes 1.051K packages.
    . ubuntu/questing/universe: 'ubuntu/questing-updates/universe' contributes 1.327K packages.
    . ubuntu/questing/universe: 'ubuntu/questing/universe' contributes 65.478K packages.
  ? ubuntu/noble/universe: Complete. Catalog contained 7.131K version bundles and 58.661K single-version packages.
  ? ubuntu/resolute/main: Generating catalog...
    . ubuntu/resolute/main: 'ubuntu/resolute-backports/main' contains 0 packages and is skipped.
    . ubuntu/resolute/main: 'ubuntu/resolute-security/main' contributes 111 packages.
    . ubuntu/resolute/main: 'ubuntu/resolute-updates/main' contributes 314 packages.
    . ubuntu/resolute/main: 'ubuntu/resolute/main' contributes 6.486K packages.
  ? ubuntu/resolute/main: Complete. Catalog contained 293 version bundles and 6.214K single-version packages.
  ? ubuntu/resolute/multiverse: Generating catalog...
    . ubuntu/resolute/multiverse: 'ubuntu/resolute-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/resolute/multiverse: 'ubuntu/resolute-security/multiverse' contains 0 packages and is skipped.
    . ubuntu/resolute/multiverse: 'ubuntu/resolute-updates/multiverse' contains 0 packages and is skipped.
    . ubuntu/resolute/multiverse: 'ubuntu/resolute/multiverse' contributes 1.242K packages.
  ? ubuntu/resolute/multiverse: Complete. Catalog contained 0 version bundles and 1.242K single-version packages.
  ? ubuntu/resolute/restricted: Generating catalog...
    . ubuntu/resolute/restricted: 'ubuntu/resolute-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/resolute/restricted: 'ubuntu/resolute-security/restricted' contains 0 packages and is skipped.
    . ubuntu/resolute/restricted: 'ubuntu/resolute-updates/restricted' contributes 169 packages.
    . ubuntu/resolute/restricted: 'ubuntu/resolute/restricted' contributes 858 packages.
  ? ubuntu/resolute/restricted: Complete. Catalog contained 152 version bundles and 723 single-version packages.
  ? ubuntu/resolute/universe: Generating catalog...
    . ubuntu/resolute/universe: 'ubuntu/resolute-backports/universe' contains 0 packages and is skipped.
    . ubuntu/resolute/universe: 'ubuntu/resolute-security/universe' contributes 79 packages.
    . ubuntu/resolute/universe: 'ubuntu/resolute-updates/universe' contributes 79 packages.
    . ubuntu/resolute/universe: 'ubuntu/resolute/universe' contributes 66.733K packages.
  ? ubuntu/questing/universe: Complete. Catalog contained 1.207K version bundles and 64.391K single-version packages.
  ? ubuntu/trusty/main: Generating catalog...
    . ubuntu/trusty/main: 'ubuntu/trusty-backports/main' contributes 63 packages.
    . ubuntu/trusty/main: 'ubuntu/trusty-security/main' contributes 2.806K packages.
    . ubuntu/trusty/main: 'ubuntu/trusty-updates/main' contributes 4.994K packages.
    . ubuntu/trusty/main: 'ubuntu/trusty/main' contributes 8.566K packages.
  ? ubuntu/trusty/main: Complete. Catalog contained 4.292K version bundles and 5.015K single-version packages.
  ? ubuntu/trusty/multiverse: Generating catalog...
    . ubuntu/trusty/multiverse: 'ubuntu/trusty-backports/multiverse' contributes 4 packages.
    . ubuntu/trusty/multiverse: 'ubuntu/trusty-security/multiverse' contributes 17 packages.
    . ubuntu/trusty/multiverse: 'ubuntu/trusty-updates/multiverse' contributes 65 packages.
    . ubuntu/trusty/multiverse: 'ubuntu/trusty/multiverse' contributes 741 packages.
  ? ubuntu/trusty/multiverse: Complete. Catalog contained 55 version bundles and 704 single-version packages.
  ? ubuntu/trusty/restricted: Generating catalog...
    . ubuntu/trusty/restricted: 'ubuntu/trusty-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/trusty/restricted: 'ubuntu/trusty-security/restricted' contributes 77 packages.
    . ubuntu/trusty/restricted: 'ubuntu/trusty-updates/restricted' contributes 86 packages.
    . ubuntu/trusty/restricted: 'ubuntu/trusty/restricted' contributes 49 packages.
  ? ubuntu/trusty/restricted: Complete. Catalog contained 56 version bundles and 40 single-version packages.
  ? ubuntu/trusty/universe: Generating catalog...
    . ubuntu/trusty/universe: 'ubuntu/trusty-backports/universe' contributes 244 packages.
    . ubuntu/trusty/universe: 'ubuntu/trusty-security/universe' contributes 1.6K packages.
    . ubuntu/trusty/universe: 'ubuntu/trusty-updates/universe' contributes 2.878K packages.
    . ubuntu/trusty/universe: 'ubuntu/trusty/universe' contributes 35.524K packages.
  ? ubuntu/trusty/universe: Complete. Catalog contained 2.713K version bundles and 33.113K single-version packages.
  ? ubuntu/xenial/main: Generating catalog...
    . ubuntu/xenial/main: 'ubuntu/xenial-backports/main' contributes 33 packages.
    . ubuntu/xenial/main: 'ubuntu/xenial-security/main' contributes 3.92K packages.
    . ubuntu/xenial/main: 'ubuntu/xenial-updates/main' contributes 5.548K packages.
    . ubuntu/xenial/main: 'ubuntu/xenial/main' contributes 7.322K packages.
  ? ubuntu/resolute/universe: Complete. Catalog contained 79 version bundles and 66.654K single-version packages.
  ? ubuntu/xenial/multiverse: Generating catalog...
    . ubuntu/xenial/multiverse: 'ubuntu/xenial-backports/multiverse' contains 0 packages and is skipped.
    . ubuntu/xenial/multiverse: 'ubuntu/xenial-security/multiverse' contributes 31 packages.
    . ubuntu/xenial/multiverse: 'ubuntu/xenial-updates/multiverse' contributes 80 packages.
    . ubuntu/xenial/multiverse: 'ubuntu/xenial/multiverse' contributes 782 packages.
  ? ubuntu/xenial/multiverse: Complete. Catalog contained 75 version bundles and 716 single-version packages.
  ? ubuntu/xenial/restricted: Generating catalog...
    . ubuntu/xenial/restricted: 'ubuntu/xenial-backports/restricted' contains 0 packages and is skipped.
    . ubuntu/xenial/restricted: 'ubuntu/xenial-security/restricted' contributes 38 packages.
    . ubuntu/xenial/restricted: 'ubuntu/xenial-updates/restricted' contributes 39 packages.
    . ubuntu/xenial/restricted: 'ubuntu/xenial/restricted' contributes 45 packages.
  ? ubuntu/xenial/restricted: Complete. Catalog contained 34 version bundles and 22 single-version packages.
  ? ubuntu/xenial/universe: Generating catalog...
    . ubuntu/xenial/universe: 'ubuntu/xenial-backports/universe' contributes 42 packages.
    . ubuntu/xenial/universe: 'ubuntu/xenial-security/universe' contributes 3.286K packages.
  ? ubuntu/xenial/main: Complete. Catalog contained 3.634K version bundles and 5.618K single-version packages.
    . ubuntu/xenial/universe: 'ubuntu/xenial-updates/universe' contributes 5.094K packages.
    . ubuntu/xenial/universe: 'ubuntu/xenial/universe' contributes 45.688K packages.
  ? ubuntu/xenial/universe: Complete. Catalog contained 4.304K version bundles and 42.213K single-version packages.
Observables successfully generated after 3m 48.2s.
Completed successfully after 5m 59.3s.
```
